### PR TITLE
chore: rename repo Dragonfly2 to dragonfly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,18 @@ It is warmly welcomed if you have interest to hack on Dragonfly. First, we encou
 
 ## Topics
 
-* [Reporting security issues](#reporting-security-issues)
-* [Reporting general issues](#reporting-general-issues)
-* [Code and doc contribution](#code-and-doc-contribution)
-* [Engage to help anything](#engage-to-help-anything)
+- [Reporting security issues](#reporting-security-issues)
+- [Reporting general issues](#reporting-general-issues)
+- [Code and doc contribution](#code-and-doc-contribution)
+- [Engage to help anything](#engage-to-help-anything)
 
 ## Reporting security issues
 
-Security issues are always treated seriously. As our usual principle, we discourage anyone to spread security issues. If you find a security issue of Dragonfly, please do not discuss it in public and even do not open a public issue. Instead we encourage you to send us a private email to  [dragonfly@alibaba-inc.com](mailto:dragonfly@alibaba-inc.com) to report this.
+Security issues are always treated seriously. As our usual principle, we discourage anyone to spread security issues. If you find a security issue of Dragonfly, please do not discuss it in public and even do not open a public issue. Instead we encourage you to send us a private email to [dragonfly@alibaba-inc.com](mailto:dragonfly@alibaba-inc.com) to report this.
 
 ## Reporting general issues
 
-To be honest, we regard every user of Dragonfly as a very kind contributor. After experiencing Dragonfly, you may have some feedback for the project. Then feel free to open an issue via [NEW ISSUE](https://github.com/dragonflyoss/Dragonfly2/issues/new).
+To be honest, we regard every user of Dragonfly as a very kind contributor. After experiencing Dragonfly, you may have some feedback for the project. Then feel free to open an issue via [NEW ISSUE](https://github.com/dragonflyoss/dragonfly/issues/new).
 
 Since we collaborate project Dragonfly in a distributed way, we appreciate **WELL-WRITTEN**, **DETAILED**, **EXPLICIT** issue reports. To make the communication more efficient, we wish everyone could search if your issue is an existing one in the searching list. If you find it existing, please add your details in comments under the existing issue instead of opening a brand-new one.
 
@@ -23,16 +23,16 @@ To make the issue details as standard as possible, we setup an [ISSUE TEMPLATE](
 
 There are lot of cases when you could open an issue:
 
-* bug report
-* feature request
-* performance issues
-* feature proposal
-* feature design
-* help wanted
-* doc incomplete
-* test improvement
-* any questions on project
-* and so on
+- bug report
+- feature request
+- performance issues
+- feature proposal
+- feature design
+- help wanted
+- doc incomplete
+- test improvement
+- any questions on project
+- and so on
 
 Also we must remind that when filing a new issue, please remember to remove the sensitive data from your post. Sensitive data could be password, secret key, network locations, private business data and so on.
 
@@ -40,16 +40,16 @@ Also we must remind that when filing a new issue, please remember to remove the 
 
 Every action to make project Dragonfly better is encouraged. On GitHub, every improvement for Dragonfly could be via a PR (short for pull request).
 
-* If you find a typo, try to fix it!
-* If you find a bug, try to fix it!
-* If you find some redundant codes, try to remove them!
-* If you find some test cases missing, try to add them!
-* If you could enhance a feature, please **DO NOT** hesitate!
-* If you find code implicit, try to add comments to make it clear!
-* If you find code ugly, try to refactor that!
-* If you can help to improve documents, it could not be better!
-* If you find document incorrect, just do it and fix that!
-* ...
+- If you find a typo, try to fix it!
+- If you find a bug, try to fix it!
+- If you find some redundant codes, try to remove them!
+- If you find some test cases missing, try to add them!
+- If you could enhance a feature, please **DO NOT** hesitate!
+- If you find code implicit, try to add comments to make it clear!
+- If you find code ugly, try to refactor that!
+- If you can help to improve documents, it could not be better!
+- If you find document incorrect, just do it and fix that!
+- ...
 
 Actually it is impossible to list them completely. Just remember one princinple:
 
@@ -57,22 +57,22 @@ Actually it is impossible to list them completely. Just remember one princinple:
 
 Since you are ready to improve Dragonfly with a PR, we suggest you could take a look at the PR rules here.
 
-* [Workspace Preparation](#workspace-preparation)
-* [Branch Definition](#branch-definition)
-* [Commit Rules](#commit-rules)
-* [PR Description](#pr-description)
+- [Workspace Preparation](#workspace-preparation)
+- [Branch Definition](#branch-definition)
+- [Commit Rules](#commit-rules)
+- [PR Description](#pr-description)
 
 ### Workspace Preparation
 
 To put forward a PR, we assume you have registered a GitHub ID. Then you could finish the preparation in the following steps:
 
-1. **FORK** Dragonfly to your repository. To make this work, you just need to click the button Fork in right-left of [dragonflyoss/Dragonfly](https://github.com/dragonflyoss/Dragonfly2) main page. Then you will end up with your repository in `https://github.com/<your-username>/Dragonfly2`, in which `your-username` is your GitHub username.
-1. **CLONE** your own repository to develop locally. Use `git clone https://github.com/<your-username>/Dragonfly2.git` to clone repository to your local machine. Then you can create new branches to finish the change you wish to make.
+1. **FORK** Dragonfly to your repository. To make this work, you just need to click the button Fork in right-left of [dragonflyoss/Dragonfly](https://github.com/dragonflyoss/dragonfly) main page. Then you will end up with your repository in `https://github.com/<your-username>/dragonfly`, in which `your-username` is your GitHub username.
+1. **CLONE** your own repository to develop locally. Use `git clone https://github.com/<your-username>/dragonfly.git` to clone repository to your local machine. Then you can create new branches to finish the change you wish to make.
 
-1. **Set Remote** upstream to be `https://github.com/dragonflyoss/Dragonfly2.git` using the following two commands:
+1. **Set Remote** upstream to be `https://github.com/dragonflyoss/dragonfly.git` using the following two commands:
 
 ```
-git remote add upstream https://github.com/dragonflyoss/Dragonfly2.git
+git remote add upstream https://github.com/dragonflyoss/dragonfly.git
 git remote set-url --push upstream no-pushing
 ```
 
@@ -80,9 +80,9 @@ With this remote setting, you can check your git remote configuration like this:
 
 ```
 $ git remote -v
-origin     https://github.com/<your-username>/Dragonfly2.git (fetch)
-origin     https://github.com/<your-username>/Dragonfly2.git (push)
-upstream   https://github.com/dragonflyoss/Dragonfly2.git (fetch)
+origin     https://github.com/<your-username>/dragonfly.git (fetch)
+origin     https://github.com/<your-username>/dragonfly.git (push)
+upstream   https://github.com/dragonflyoss/dragonfly.git (fetch)
 upstream   no-pushing (push)
 ```
 
@@ -90,7 +90,7 @@ Adding this, we can easily synchronize local branches with upstream branches.
 
 ### Branch Definition
 
-Right now we assume every contribution via pull request is for [branch master](https://github.com/dragonflyoss/Dragonfly2/tree/main) in Dragonfly. Before contributing, be aware of branch definition would help a lot.
+Right now we assume every contribution via pull request is for [branch master](https://github.com/dragonflyoss/dragonfly/tree/main) in Dragonfly. Before contributing, be aware of branch definition would help a lot.
 
 As a contributor, keep in mind again that every contribution via pull request is for branch master. While in project Dragonfly, there are several other branches, we generally call them rc branches, release branches and backport branches.
 
@@ -104,34 +104,34 @@ When backporting some fixes to existing released version, we will checkout backp
 
 Actually in Dragonfly, we take two rules serious when committing:
 
-* [Commit Message](#commit-message)
-* [Commit Content](#commit-content)
+- [Commit Message](#commit-message)
+- [Commit Content](#commit-content)
 
 #### Commit Message
 
 Commit message could help reviewers better understand what is the purpose of submitted PR. It could help accelerate the code review procedure as well. We encourage contributors to use **EXPLICIT** commit message rather than ambiguous message. In general, we advocate the following commit message type:
 
-* docs: xxxx. For example, "docs: add docs about storage installation".
-* feature: xxxx.For example, "feature: make result show in sorted order".
-* bugfix: xxxx. For example, "bugfix: fix panic when input nil parameter".
-* style: xxxx. For example, "style: format the code style of Constants.java".
-* refactor: xxxx. For example, "refactor: simplify to make codes more readable".
-* test: xxx. For example, "test: add unit test case for func InsertIntoArray".
-* chore: xxx. For example, "chore: integrate travis-ci". It's the type of maintenance change.
-* other readable and explicit expression ways.
+- docs: xxxx. For example, "docs: add docs about storage installation".
+- feature: xxxx.For example, "feature: make result show in sorted order".
+- bugfix: xxxx. For example, "bugfix: fix panic when input nil parameter".
+- style: xxxx. For example, "style: format the code style of Constants.java".
+- refactor: xxxx. For example, "refactor: simplify to make codes more readable".
+- test: xxx. For example, "test: add unit test case for func InsertIntoArray".
+- chore: xxx. For example, "chore: integrate travis-ci". It's the type of maintenance change.
+- other readable and explicit expression ways.
 
 On the other side, we discourage contributors from committing message like the following ways:
 
-* ~~fix bug~~
-* ~~update~~
-* ~~add doc~~
+- ~~fix bug~~
+- ~~update~~
+- ~~add doc~~
 
 #### Commit Content
 
 Commit content represents all content changes included in one commit. We had better include things in one single commit which could support reviewer's complete review without any other commits' help. In another word, contents in one single commit can pass the CI to avoid code mess. In brief, there are two minor rules for us to keep in mind:
 
-* avoid very large change in a commit;
-* complete and reviewable for each commit.
+- avoid very large change in a commit;
+- complete and reviewable for each commit.
 
 No matter commit message, or commit content, we do take more emphasis on code review.
 
@@ -143,12 +143,12 @@ PR is the only way to make change to Dragonfly project files. To help reviewers 
 
 We choose GitHub as the primary place for Dragonfly to collaborate. So the latest updates of Dragonfly are always here. Although contributions via PR is an explicit way to help, we still call for any other ways.
 
-* reply to other's issues if you could;
-* help solve other user's problems;
-* help review other's PR design;
-* help review other's codes in PR;
-* discuss Dragonfly to make things clearer;
-* advocate Dragonfly technology beyond GitHub;
-* write blogs on Dragonfly and so on.
+- reply to other's issues if you could;
+- help solve other user's problems;
+- help review other's PR design;
+- help review other's codes in PR;
+- discuss Dragonfly to make things clearer;
+- advocate Dragonfly technology beyond GitHub;
+- write blogs on Dragonfly and so on.
 
 In a word, **ANY HELP IS CONTRIBUTION.**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Planning
 
-This document outlines Dragonfly process for planning and scheduling releases, so you can familiarize yourself with the flow of work from opening an issue to seeing it published in a release. We aim to ship updates to production approximately every 6 months, to ensure a continuous flow of improvements to our users. 
+This document outlines Dragonfly process for planning and scheduling releases, so you can familiarize yourself with the flow of work from opening an issue to seeing it published in a release. We aim to ship updates to production approximately every 6 months, to ensure a continuous flow of improvements to our users.
 
 ## Release version
 
@@ -8,28 +8,29 @@ All release artifacts must follow [Semantic Versioning](https://semver.org). Eac
 
 We organize releases in two ways - marketing and milestones:
 
- - Marketing releases are what we use to represent stable version.
-      - **for example: v2.1, v2.2, etc.**
- - Milestones are used to track issues and pull requests associated with an upcoming release, and can be [followed on GitHub](https://github.com/Dragonflyoss/Dragonfly2/milestones)
-      - **for example: v2.1.x, v2.1.0-alpha.x, v2.1.0-beta.x, etc.**
+- Marketing releases are what we use to represent stable version.
+  - **for example: v2.1, v2.2, etc.**
+- Milestones are used to track issues and pull requests associated with an upcoming release, and can be [followed on GitHub](https://github.com/Dragonflyoss/dragonfly/milestones)
+  - **for example: v2.1.x, v2.1.0-alpha.x, v2.1.0-beta.x, etc.**
 
 Hotfixes should also be applied directly into each of the impacted release branches. Then, the fix can be merged back into master (or main) branch or cherry-picked.
 
 ## Release milestone
 
 The Dragonfly project maintains a dynamic development cycle, addressing both existing feature bugs and implementing new functionalities. Each release follows a structured 26-week (6-month) timeline, divided into three key phases:
--	Feature definition (~ 4 weeks)
--	Feature implementation (~ 18 weeks)
--	Stabilization and release (~ 4 weeks)
+
+- Feature definition (~ 4 weeks)
+- Feature implementation (~ 18 weeks)
+- Stabilization and release (~ 4 weeks)
 
 Given the complexity of significant features, their full integration often spans multiple release cycles. As a release nears completion, it's not uncommon for complex features to be rescheduled for the subsequent milestone. This approach ensures each feature meets the rigorous requirements of the project's feature lifecycle, maintaining the high quality standards of the Dragonfly project.
 
 ## Release note
 
-[Dragonfly Maintainers](https://github.com/dragonflyoss/Dragonfly2/blob/main/MAINTAINERS.md) from different companies take turns to prepare key information such as [release notes](https://d7y.io/docs/next/roadmap-v2.2/).
+[Dragonfly Maintainers](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md) from different companies take turns to prepare key information such as [release notes](https://d7y.io/docs/next/roadmap-v2.2/).
 
 ## Release team
 
 The release team has the responsibility of enforcing processes to ensure the release is successfully delivered. The release team consists of the following roles:
 
--	**Release manager.**  This role oversees enforcing the processes for a release and ensuring communication to all contributors and community on the ongoing status of the release. For each release, one release manager is selected from each participating company.
+- **Release manager.** This role oversees enforcing the processes for a release and ensuring communication to all contributors and community on the ongoing status of the release. For each release, one release manager is selected from each participating company.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,14 @@ The project maintainers update this roadmap annually following each major releas
 
 ## Releases
 
-For each Dragonfly release, a corresponding [GitHub milestone](https://github.com/dragonflyoss/Dragonfly2/milestones) is established, bearing the name of the release version. GitHub issues are assigned to each milestones to effectively track the scope and progress of each release. 
+For each Dragonfly release, a corresponding [GitHub milestone](https://github.com/dragonflyoss/dragonfly/milestones) is established, bearing the name of the release version. GitHub issues are assigned to each milestones to effectively track the scope and progress of each release.
 
 ### Current Release
 
-The current Dragonfly release is v2.1. Details can be found in the [release notes](https://github.com/dragonflyoss/Dragonfly2/releases/tag/v2.1.0).
+The current Dragonfly release is v2.1. Details can be found in the [release notes](https://github.com/dragonflyoss/dragonfly/releases/tag/v2.1.0).
 
 ### Next Release
 
 The next release is v2.2 This release is currently in development. For details on upcoming features and important changes, please see our [v2.2 roadmap](https://d7y.io/docs/next/roadmap-v2.2/).
 
-Dragonfly encourages innovation and continuous improvement. Before proposing a new idea, please check existing issues in the relevant Dragonfly repositories to avoid duplication and ensure your contribution is unique. For suggestions involving new APIs or significant changes to the Dragonfly runtime, please submit these in the Dragonfly [issues tracker](https://github.com/dragonflyoss/Dragonfly2/issues). 
+Dragonfly encourages innovation and continuous improvement. Before proposing a new idea, please check existing issues in the relevant Dragonfly repositories to avoid duplication and ensure your contribution is unique. For suggestions involving new APIs or significant changes to the Dragonfly runtime, please submit these in the Dragonfly [issues tracker](https://github.com/dragonflyoss/dragonfly/issues).


### PR DESCRIPTION
This pull request includes updates to various documentation files to correct URLs and improve formatting consistency.

### Documentation updates:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L7-R93): Updated repository URLs from `Dragonfly2` to `dragonfly` and adjusted formatting for consistency. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L7-R93) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L107-R134) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L146-R152)
* [`RELEASE.md`](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL13-R21): Corrected URLs for milestones and maintainers to point to the correct repository. [[1]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL13-R21) [[2]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cL29-R30)
* [`ROADMAP.md`](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L9-R19): Updated URLs for milestones and release notes to reflect the current repository structure.

Issue: https://github.com/dragonflyoss/dragonfly/issues/3714