### PR TITLE
docs(ROADMAP.md): Update ROADMAP.md to reflect current release v2.2 and next release v2.3

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,10 +10,10 @@ For each Dragonfly release, a corresponding [GitHub milestone](https://github.co
 
 ### Current Release
 
-The current Dragonfly release is v2.1. Details can be found in the [release notes](https://github.com/dragonflyoss/dragonfly/releases/tag/v2.1.0).
+The current Dragonfly release is v2.2 Details can be found in the [release notes](https://github.com/dragonflyoss/dragonfly/releases/tag/v2.2.0).
 
 ### Next Release
 
-The next release is v2.2 This release is currently in development. For details on upcoming features and important changes, please see our [v2.2 roadmap](https://d7y.io/docs/next/roadmap-v2.2/).
+The next release is v2.3 This release is currently in development. For details on upcoming features and important changes, please see our [v2.3 roadmap](https://d7y.io/docs/next/roadmap-v2.3/).
 
 Dragonfly encourages innovation and continuous improvement. Before proposing a new idea, please check existing issues in the relevant Dragonfly repositories to avoid duplication and ensure your contribution is unique. For suggestions involving new APIs or significant changes to the Dragonfly runtime, please submit these in the Dragonfly [issues tracker](https://github.com/dragonflyoss/dragonfly/issues).


### PR DESCRIPTION
This pull request updates the release information in the `ROADMAP.md` file to reflect the current and next versions of Dragonfly.

* Updated the current Dragonfly release from v2.1 to v2.2 and linked to the corresponding release notes. (`ROADMAP.md`, [ROADMAP.mdL13-R17](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L13-R17))
* Updated the next Dragonfly release from v2.2 to v2.3 and linked to the corresponding roadmap. (`ROADMAP.md`, [ROADMAP.mdL13-R17](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L13-R17))