### PR TITLE
docs: add community-membership.md

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -1,0 +1,170 @@
+# Dragonfly Community Membership
+
+As a CNCF member project, Dragonfly project abides by the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+This doc outlines the responsibilities of contributor roles in Dragonfly. The Dragonfly project is subdivided into sub-projects
+under (predominantly, but not exclusively) nydus, nydus-snapshotter, api, docs, console and client.
+Responsibilities for roles are scoped to these sub-projects (repos).
+
+We have six levels of responsibility including:
+
+- Contributor
+- Member
+- Approver
+- Maintainer
+
+## Contributor
+
+A Contributor is someone who has contributed to the project by submitting code, issues, or participating in discussions.
+
+### Responsibilities
+
+- Contribute code changes via pull requests (PRs).
+- Raise issues for bugs, enhancements, or other discussions.
+- Participate in code reviews if requested.
+- Follow the project's Code of Conduct and contribution guidelines.
+
+### Requirements
+
+- Have a GitHub account.
+- Sign the Contributor License Agreement (if applicable).
+- Adhere to the project's coding standards and guidelines.Contributor
+
+## Member
+
+A Member is a contributor who has shown long-term commitment to the project,
+consistently contributing high-quality work and actively participating in the community.
+
+Responsibilities:
+
+- All responsibilities of a Contributor.
+- Participate in project planning and decision-making processes.
+- Mentor new contributors.
+- Actively participate in community meetings and discussions.
+
+Requirements:
+
+- Demonstrated history of contributions (code, reviews, discussions) over at least 3 months.
+- Invitation by a Maintainer or Administrator based on consensus.
+- Continued adherence to the project's Code of Conduct.
+
+## Approver
+
+An Approver is a member who has the additional responsibility of reviewing and approving PRs that affect the project.
+
+Responsibilities:
+
+- All responsibilities of a Member.
+- Review and approve PRs from Contributors and Members.
+- Ensure that changes adhere to coding standards, do not introduce bugs, and improve the project.
+- Help triage issues and provide feedback on improvements.
+
+Requirements:
+
+- Demonstrated expertise in the project’s codebase.
+- Consistent and high-quality contributions.
+- Trusted by Maintainers and Administrators to provide accurate reviews and approvals.
+
+## Maintainer
+
+A Maintainer is an experienced and trusted member who has extensive knowledge of the project, including architecture
+and design principles. Maintainers have the authority to merge PRs and make significant project decisions.
+
+Responsibilities:
+
+- All responsibilities of an Approver.
+- Merge PRs to the main branch.
+- Ensure the overall quality, stability, and performance of the codebase.
+- Coordinate releases and update documentation.
+- Guide the project's technical direction and roadmap.
+- Facilitate communication and collaboration within the community.
+
+Requirements:
+
+- Demonstrated long-term, high-quality contributions and leadership in the project.
+- Deep understanding of the project’s architecture and design.
+- Commitment to the project's goals and values.
+- Nominated and approved by existing Maintainers and Administrators.
+
+### Maintainership
+
+Maintainers of Dragonfly share the responsibility. And they have 3 things in general:
+
+- share responsibility in the project's success;
+- make a long-term investment to improve the project;
+- spend time doing whatever needs to, not only the most interesting part;
+
+Maintainers are often working hard, but sometimes what they do is hardly appreciate.
+It is easy to work on the fancy part or technically advanced feature. It is harder
+to work on minor bugfix, small improvement, long-term stable optimization or
+others. While all of the above is the essential parts to build up a successful project.
+
+### Adding Maintainers
+
+Maintainers are foremost and first contributors that have dedicated to the long
+term success of the project. Contributors wishing to become maintainers are
+expected to deeply involved in tackling issues, contributing codes, review
+proposals and codes for more than two months.
+
+Maintainership is built on trust. Trust is totally beyond just contributing
+code. Thus it is definitely worthy to achieving current maintainers' trust via
+bringing best interest for the project.
+
+New maintainers are nominated by an existing maintainer (via PR) and require
+a supermajority vote from current maintainers for election.
+Similarly, maintainers can be removed by a supermajority vote
+of existing maintainers or may resign by notifying any maintainer.
+
+### Removal of Inactive Maintainers
+
+Similar to adding maintainers, existing maintainer can been removed from the
+active maintainer list. If the existing maintainer meet one of the conditions
+below, any other maintainers can proposed to remove him from active list via a
+pull request:
+
+- A maintainer has not participated in community activities for more than last
+  three months;
+- A maintainer did not obey to the governance rules more than twice;
+
+After confirming conditions above, in theory maintainer can be removed from
+list directly unless the original maintainer requests to remain maintainer seat
+and gets a vote of at least 50% of other maintainers.
+
+If a maintainer is removed from the maintaining list, other maintainers should
+at a column to the alumni part to thank the contribution made from the inactive
+maintainer.
+
+### How to make decision
+
+Dragonfly is an open-source project illustrating the concept of open. This
+means that Dragonfly repository is the source of truth for every aspect of the
+project, including raw value, design, doc, roadmap, interfaces and so on. If it
+is one part of the project, it should be in the repo.
+
+To be honest, all decisions can be regarded as an update to project.
+
+Any updates or changes which take effect on Dragonfly, no matter big or small,
+should follow three steps below:
+
+- Step 1: Open a pull request;
+- Step 2: Discuss under the pull request;
+- Step 3: Merge or refuse the pull request.
+
+When Dragonfly has less than seven maintainers, a pull request except adding
+maintainers pull request could be merged, if it meets both conditions below:
+
+- at least one active maintainer commented `LGTM` to the pull request;
+- no other maintainers have opposite opinion on it.
+
+When Dragonfly has more than seven maintainers, a pull request except adding
+maintainers pull request could be merged, if it meets conditions below:
+
+- at least two active maintainers commented `LGTM` to the pull request;
+
+When there are fewer than seven active maintainers,
+a "lazy consensus period" can be introduced as a secondary safeguard
+to prevent unintended merges of significant Pull Requests (PRs):
+during this predefined timeframe, a significant PR that has received initial approval will be held from merging,
+giving other maintainers a final opportunity to review and raise objections;
+if no objections are raised, consensus is considered reached, and the PR can be merged,
+while any objections must be resolved before proceeding.


### PR DESCRIPTION
This pull request introduces a new document, `community-membership.md`, which outlines the roles, responsibilities, and governance processes for contributors to the Dragonfly project. The document establishes clear guidelines for community participation and decision-making, with a focus on maintaining project quality and fostering collaboration.

### Community Roles and Responsibilities:
* Defined four levels of contributors: `Contributor`, `Member`, `Approver`, and `Maintainer`, with progressively increasing responsibilities and requirements.
* Provided detailed descriptions of each role, including responsibilities such as contributing code, reviewing pull requests, mentoring, and making significant project decisions.

### Governance and Decision-Making:
* Established processes for adding and removing maintainers, including nomination, voting, and criteria for inactivity.
* Documented a decision-making process for changes to the project, including pull request discussions, approval thresholds, and a "lazy consensus period" for significant pull requests.