### PR TITLE
chore: fix docs, links, and remove admin role references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ As our usual principle, we discourage anyone to spread security issues.
 If you find a security issue of Dragonfly, please do not discuss it in
 public and even do not open a public issue.
 Instead, we encourage you to send us a private email to
-[dragonfly-developers@googlegroups.com](mailto:dragonfly-developers@googlegroups.com) to report this.
+[dragonfly-maintainers@googlegroups.com](mailto:dragonfly-maintainers@googlegroups.com) to report this.
 
 ## Reporting general issues
 
@@ -321,4 +321,4 @@ You can do it in either of two ways:
 
 - Submit a PR in the
   [dragonflyoss/dragonfly](https://github.com/dragonflyoss/dragonfly) repo.
-- Contact with the community's [maintainers](MAINTAINERS.md) offline.
+- Contact with the community's [maintainers](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md) offline.

--- a/community-membership.md
+++ b/community-membership.md
@@ -28,7 +28,7 @@ A Contributor is someone who has contributed to the project by submitting code, 
 
 - Have a GitHub account.
 - Sign the Contributor License Agreement (if applicable).
-- Adhere to the project's coding standards and guidelines.Contributor
+- Adhere to the project's coding standards and guidelines.
 
 ## Member
 
@@ -45,7 +45,7 @@ Responsibilities:
 Requirements:
 
 - Demonstrated history of contributions (code, reviews, discussions) over at least 3 months.
-- Invitation by a Maintainer or Administrator based on consensus.
+- Invitation by a Maintainer based on consensus.
 - Continued adherence to the project's Code of Conduct.
 
 ## Approver
@@ -63,7 +63,7 @@ Requirements:
 
 - Demonstrated expertise in the project’s codebase.
 - Consistent and high-quality contributions.
-- Trusted by Maintainers and Administrators to provide accurate reviews and approvals.
+- Trusted by Maintainers to provide accurate reviews and approvals.
 
 ## Maintainer
 
@@ -84,7 +84,7 @@ Requirements:
 - Demonstrated long-term, high-quality contributions and leadership in the project.
 - Deep understanding of the project’s architecture and design.
 - Commitment to the project's goals and values.
-- Nominated and approved by existing Maintainers and Administrators.
+- Nominated and approved by existing Maintainers.
 
 ### Maintainership
 


### PR DESCRIPTION
## Description

A collection of small fixes:
- Fixes some docs
- Removes references to administrator role since it was removed.
- Updates the security contact address from dragonfly-discuss to dragonfly-maintainers. (security concerns should be sent to a private list for initial triage and discussion)

## Related Issue
 
 #27 

## Motivation and Context

Follow up on governance items

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] My change requires a change to the documentation. | N/A
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. | N/A
