### PR TITLE
docs: Update records for 2025-06-17 Maintainer Meeting with attendees, issues, and actions

### DIFF
--- a/meetings/maintainer/2025-06-17/README.md
+++ b/meetings/maintainer/2025-06-17/README.md
@@ -1,16 +1,64 @@
 # Maintainer Meeting
 
+## Attendees
+
+- [Yiyang Huang](https://github.com/hyy0322) (ByteDance/Dragonfly)
+- [Han Jiang](https://github.com/CormickKneey) (Kuaishou/Dragonfly)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Liu Zhao](https://github.com/BraveY) (Ant Group/Nydus)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [Peng Tao](https://github.com/bergwolf) (Ant Group/Nydus)
+- [Cheng Ming](https://github.com/mingcheng) (Ant Group/Dragonfly)
+- [Muyu Yang](https://github.com/LunaWhispers) (Ant Group/Dragonfly)
+- [Xinxin Zhao](https://github.com/Liam-Zhao) (Dragonfly)
+
 ## Topics
 
-- Discussion on community governance issues and election of new community management.
-- Fluid will support Model Artifact by OCI Spec, and Dragonfly needs to support P2P distribution of Model layers.
-- VLLM will support Model Artifact by OCI Spec, and Dragonfly needs to support P2P distribution of Model layers.
+- Discussion on community governance issues and election of new community management. @mingcheng @gaius-qi
+- Fluid will support Model Artifact by OCI Spec, and Dragonfly needs to support P2P distribution of Model layers. @chlins @gaius-qi
+- VLLM will support Model Artifact by OCI Spec, and Dragonfly needs to support P2P distribution of Model layers. @CormickKneey
 
 ## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
 
 ### Github Issue
 
+- https://github.com/dragonflyoss/dragonfly/issues/4138 @yxxhero
+- https://github.com/dragonflyoss/dragonfly/issues/2956 @yxxhero
+- https://github.com/dragonflyoss/client/issues/1116 @yxxhero
+- https://github.com/dragonflyoss/dragonfly/issues/4112 @fcgxz2003
+- https://github.com/dragonflyoss/dragonfly/issues/2559 @fcgxz2003
+- https://github.com/dragonflyoss/helm-charts/issues/242 @fcgxz2003
+- https://github.com/dragonflyoss/dragonfly/issues/2956 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/3031 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/3566 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/4040 @gaius-qi
+- https://github.com/dragonflyoss/client/issues/1083 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/3733 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/3771 @chlins
+- https://github.com/dragonflyoss/helm-charts/issues/363 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/3744 @CormickKneey
+- https://github.com/dragonflyoss/helm-charts/issues/350 @CormickKneey
+- https://github.com/dragonflyoss/dragonfly/issues/3807 @mingcheng
+- https://github.com/dragonflyoss/dragonfly/issues/3816 @hyy0322
+- https://github.com/dragonflyoss/dragonfly/issues/4130 @hyy0322
+- https://github.com/dragonflyoss/dragonfly/issues/3981 @LunaWhispers
+- https://github.com/dragonflyoss/dragonfly/issues/4094 @LunaWhispers
+- https://github.com/dragonflyoss/helm-charts/issues/244 @LunaWhispers
+- https://github.com/dragonflyoss/dragonfly/issues/4020 @Liam-Zhao
+- https://github.com/dragonflyoss/helm-charts/issues/387 @imeoer
+- https://github.com/dragonflyoss/helm-charts/issues/293 @BraveY
+
 ### Slack Issue
+
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1741188384363019 @CormickKneey
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1741616297121759 @yxxhero
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1742891332327109 @chlins
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1742572826462699 @LunaWhispers
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1747035632085719?thread_ts=1742891332.327109&cid=C038X8KH1QT @hyy0322
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1747600751800069 @fcgxz2003
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1748293597062079 @fcgxz2003
 
 ## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
 
@@ -22,3 +70,12 @@
 - Participants: @LunaWhispers
 
 ## Actions
+
+- [ ] Collect information of the conference promotion and organiz members to participate. @mingcheng
+- [ ] Collect old version release notes and add them to the Dragonfly Website, refer to https://www.cncf.io/?s=dragonfly. @mingcheng
+- [ ] Improve governance community documentation and processes. @mingcheng
+- [ ] Handle with issues in the nydus project that have not been responded to for a long time and tag the issues. @imeoer @BraveY
+- [ ] Add actions for Close stale issues and PRs in the Nydus. @imeoer @BraveY
+- [ ] Support Model Artifact by OCI Spec in VLLM, and Dragonfly needs to support P2P distribution of Model layers. @CormickKneey
+- [ ] Support Model Artifact by OCI Spec in VLLM, and Dragonfly needs to support P2P distribution of Model layers. @chlins @gaius-qi
+- [ ] Collect the next meeting topics and host the next meeting. @chlins


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the `README.md` for the maintainer meeting on June 17, 2025, by adding attendee information, assigning responsibilities for discussion topics and issues, and documenting action items for follow-up tasks. These changes enhance clarity and organization for the meeting's agenda and outcomes.

### Meeting documentation updates:

* Added a list of attendees with GitHub profiles and affiliations to the meeting documentation. (`meetings/maintainer/2025-06-17/README.md`)

### Topic and issue tracking:

* Assigned responsibilities for discussion topics and linked relevant GitHub issues with assignees for better tracking. (`meetings/maintainer/2025-06-17/README.md`)
* Linked Slack issues with assignees for improved communication and follow-up. (`meetings/maintainer/2025-06-17/README.md`)

### Action item documentation:

* Documented action items for tasks such as governance improvements, stale issue management, and support for Model Artifact by OCI Spec, along with assignees for accountability. (`meetings/maintainer/2025-06-17/README.md`)
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
