### PR TITLE
docs: add the community record of 2025-07-15

### DIFF
--- a/meetings/maintainer/2025-07-15/README.md
+++ b/meetings/maintainer/2025-07-15/README.md
@@ -44,6 +44,7 @@
 - https://github.com/dragonflyoss/dragonfly/issues/4094 @LunaWhispers
 - https://github.com/dragonflyoss/helm-charts/issues/244 @LunaWhispers
 - https://github.com/dragonflyoss/dragonfly/issues/4160 @gaius-qi
+- https://github.com/dragonflyoss/nydus/issues/1713 @BraveY
 
 #### Done
 

--- a/meetings/maintainer/2025-07-15/README.md
+++ b/meetings/maintainer/2025-07-15/README.md
@@ -1,0 +1,87 @@
+# Maintainer Meeting
+
+## Attendees
+
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Liu Zhao](https://github.com/BraveY) (Ant Group/Nydus)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation
+/Dragonfly)
+- [Muyu Yang](https://github.com/LunaWhispers) (Ant Group/Dragonfly)
+- [Xinxin Zhao](https://github.com/Liam-Zhao) (Dragonfly)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud)
+- [Chaozhi Ma](https://github.com/ClementMaH) (Alibaba Cloud)
+- [Yuan Yang](https://github.com/yyzai384) (Alibaba Cloud)
+
+
+## Topics
+
+## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+### Github Issue
+
+#### TODO
+
+- https://github.com/dragonflyoss/client/issues/1214 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/4202 @yyzai384
+- https://github.com/dragonflyoss/dragonfly/issues/4195 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/4204 @chlins
+- https://github.com/dragonflyoss/nydus/issues/1715 @imeoer
+- https://github.com/dragonflyoss/nydus/issues/1719 @BraveY
+
+#### WIP
+
+- https://github.com/dragonflyoss/helm-charts/issues/363 @chlins
+- https://github.com/dragonflyoss/helm-charts/issues/387 @imeoer
+- https://github.com/dragonflyoss/client/issues/1116 @yxxhero
+- https://github.com/dragonflyoss/dragonfly/issues/3733 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/3771 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/3744 @CormickKneey
+- https://github.com/dragonflyoss/dragonfly/issues/3807 @mingcheng
+- https://github.com/dragonflyoss/dragonfly/issues/3816 @hyy0322
+- https://github.com/dragonflyoss/dragonfly/issues/3981 @LunaWhispers
+- https://github.com/dragonflyoss/dragonfly/issues/4094 @LunaWhispers
+- https://github.com/dragonflyoss/helm-charts/issues/244 @LunaWhispers
+- https://github.com/dragonflyoss/dragonfly/issues/4160 @gaius-qi
+
+#### Done
+
+- https://github.com/dragonflyoss/dragonfly/issues/4138 @yxxhero
+- https://github.com/dragonflyoss/dragonfly/issues/4040 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/4130 @hyy0322
+- https://github.com/dragonflyoss/console/issues/552 @Liam-Zhao
+
+### Slack Issue
+
+#### To Reply
+
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1741188384363019 @CormickKneey
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1741616297121759 @yxxhero
+
+#### To Resolve
+
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1742891332327109 @chlins
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1747035632085719?thread_ts=1742891332.327109&cid=C038X8KH1QT @hyy0322
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1747600751800069 @fcgxz2003
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1748293597062079 @fcgxz2003
+
+#### Resolved
+
+- https://cloud-native.slack.com/archives/C038X8KH1QT/p1742572826462699 @LunaWhispers
+
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+## Actions
+
+- [ ] Next meeting topic collection and organization @mingcheng
+- [ ] Establishment of rules for the distribution of issues: The bi-weekly meeting facilitator collects recent unprocessed issues two days before each bi-weekly meeting and notifies developers to claim them themselves. For unclaimed issues, assign someone to handle them. @all
+- [ ] Collect information of the conference promotion and organize members to participate. @mingcheng
+- [ ] Complete the final version of the graduation proposal and application document by this Friday. And complete PR review and merge next week. @mingcheng 
+- [ ] Put the graduation application document for developers to review together. @mingcheng
+- [ ] Handle with issues in the nydus project that have not been responded to for a long time and tag the issues. @imeoer @BraveY
+- [ ] Support Model Artifact by OCI Spec in VLLM, and Dragonfly needs to support P2P distribution of Model layers. @CormickKneey
+- [ ] Support Model Artifact by OCI Spec in Fluid, and Dragonfly needs to support P2P distribution of Model layers. @chlins @gaius-qi
+- [ ] Update devlopment guideance @CooooolFrog
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds a detailed agenda and discussion notes for the maintainer meeting held on July 15, 2025, in the README.md file under meetings/maintainer/2025-07-15. It includes attendee information, topics discussed, action items, and categorized lists of GitHub and Slack issues.

Meeting Documentation Additions:
Added a list of attendees with their affiliations and GitHub profiles.
Documented topics discussed during the meeting, including release notes, roadmaps, and technical discussions.
Categorized GitHub issues into TODO, WIP, and Done sections for better tracking.
Categorized Slack issues into To Reply, To Resolve, and Resolved sections.
Action Items:
Listed follow-up actions, such as topic collection for the next meeting, governance improvements, and support for new features like P2P distribution of model layers.
Closes https://github.com/dragonflyoss/community/issues/48

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
