### PR TITLE
docs: update community ladder and membership guides 📚

### DIFF
--- a/COMMUNITY_LADDER.md
+++ b/COMMUNITY_LADDER.md
@@ -6,6 +6,7 @@ This document outlines the different contributor roles and responsibilities with
 - [Scope](#scope)
 - [General Guidelines](#general-guidelines)
   - [Everyone is Welcome](#everyone-is-welcome)
+  - [Guidance](#guidance)
   - [Continued Contributions](#continued-contributions)
   - [Consensus for Merging](#consensus-for-merging)
   - [Start a Discussion](#start-a-discussion)
@@ -14,7 +15,6 @@ This document outlines the different contributor roles and responsibilities with
   - [Member](#member)
   - [Approver](#approver)
   - [Maintainer](#maintainer)
-- [General Guidance on Contributions and Expectations](#general-guidance-on-contributions-and-expectations)
 
 ## Goals
 
@@ -33,9 +33,22 @@ The roles of Organization Member, Approver, or Maintainer are officially defined
 
 ## General Guidelines
 
+
+
 ### Everyone is Welcome
 
 We truly appreciate every contribution. You don't need a formal title to create or review pull requests, help with issues, or join in on discussions. Taking on a formal role is completely optional, so feel free to contribute in any way that works for you.
+
+### Guidance
+
+As described in our [Contribution Guide](CONTRIBUTING.md), we welcome all kinds of contributions, whether it's PRs, issues, or new feature ideas. If you're new here, we recommend starting with smaller, meaningful changes. They're easier to review and a great way to get familiar with our processes.
+
+Since we're an open source project, review times can vary depending on when Maintainers and Approvers are available. You can build trust and speed up your progression by making consistent, smaller contributions or by giving constructive feedback on other people's work.
+
+Every time we merge a contribution, we're committing to maintaining it for the long haul. That's why larger changes require not just a lot of effort, but also a proven track record to show the community that you'll be around to support your changes.
+
+Remember, _["no is temporary, yes is forever."](https://www.oreilly.com/library/view/hands-on-design-patterns/9781789135565/3f396314-dac8-446c-ab02-768ae91296fa.xhtml)_ 🙇‍♂️
+
 
 ### Continued Contributions
 
@@ -189,12 +202,3 @@ A **Maintainer** is a highly trusted member of the project with the authority to
 
 Maintainers who contribute to the core code are automatically part of the project's Code Team, if one is defined.
 
-## General Guidance on Contributions and Expectations
-
-We welcome all kinds of contributions, whether it's PRs, issues, or new feature ideas. If you're new here, we recommend starting with smaller, meaningful changes. They're easier to review and a great way to get familiar with our processes.
-
-Since we're an open source project, review times can vary depending on when Maintainers and Approvers are available. You can build trust and speed up your progression by making consistent, smaller contributions or by giving constructive feedback on other people's work.
-
-Every time we merge a contribution, we're committing to maintaining it for the long haul. That's why larger changes require not just a lot of effort, but also a proven track record to show the community that you'll be around to support your changes.
-
-Remember, _["no is temporary, yes is forever."](https://www.oreilly.com/library/view/hands-on-design-patterns/9781789135565/3f396314-dac8-446c-ab02-768ae91296fa.xhtml)_ 🙇‍♂️

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -1,5 +1,13 @@
 # Dragonfly Community Membership
 
+- [How We Make Decisions](#how-we-make-decisions)
+- [Managing Membership](#managing-membership)
+  - [Adding New Members](#adding-new-members)
+  - [Removing Inactive Members](#removing-inactive-members)
+- [Election Process](#election-process)
+  - [Maximum Representation](#maximum-representation)
+  - [Vacancies](#vacancies)
+
 As a proud member of the CNCF, the Dragonfly project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
 This document explains the responsibilities that come with different contributor roles in the Dragonfly community. Our project is organized into several sub-projects, including (but not limited to) nydus, nydus-snapshotter, api, docs, console, and client. The responsibilities for each role are tied to these specific sub-projects and their repositories.
@@ -25,29 +33,52 @@ If we have fewer than seven active Maintainers, an issue can be merged if:
 
 Additionally, when we have fewer than seven active Maintainers, we might use a "lazy consensus period" for significant issues. This means that after an issue gets initial approval, we'll hold it for a set amount of time (like 7 days) to give everyone a final chance to discuss it. If no one objects, it can be closed. If issues come up, we'll resolve the concerns and then proceed and move forward.
 
-## Managing Maintainership
+## Managing Membership
 
-Our Maintainers share the responsibility for the project's success. In general, they:
+Our Members share the responsibility for the project's success. In general, they:
 
 - Are accountable for the project's outcomes.
 - Are invested in the long-term improvement of the project.
 - Dedicate time to all the necessary tasks, not just the fun ones.
 
-Maintainers often work hard behind the scenes, and their efforts aren't always visible. While it's easy to get excited about new features, it's just as important—and often more challenging—to handle bug fixes, small improvements, stability optimizations, and all the other foundational work that keeps the project strong.
+Members often work hard behind the scenes, and their efforts aren't always visible. While it's easy to get excited about new features, it's just as important—and often more challenging—to handle bug fixes, small improvements, stability optimizations, and all the other foundational work that keeps the project strong.
 
-### Adding New Maintainers
+### Adding New Members
 
-Maintainers start out as dedicated contributors who are committed to the long-term success of the project. If you're aspiring to become a Maintainer, you should be actively involved in resolving issues, contributing code, and reviewing proposals and pull requests for at least two months.
+Members start out as dedicated contributors who are committed to the long-term success of the project. If you're aspiring to become a Member, you should be actively involved in resolving issues, contributing code, and reviewing proposals and pull requests for at least two months.
 
-Maintainership is built on trust, and that goes beyond just writing code. You earn the trust of the current Maintainers by consistently acting in the best interest of the project.
+Membership is built on trust, and that goes beyond just writing code. You earn the trust of the current Members by consistently acting in the best interest of the project.
 
-New Maintainers are nominated by an existing Maintainer (through a PR) and need a supermajority vote from the current Maintainers to be approved. Similarly, Maintainers can be removed by a supermajority vote, or they can choose to step down by letting any other Maintainer know.
+New Members are nominated by an existing Member (through an issue) and need a supermajority vote from the current Members to be approved. Similarly, Members can be removed by a supermajority vote, or they can choose to step down by letting any other Member know. For details on how members are selected and their terms, see the [Election Process](#election-process).
 
-### Removing Inactive Maintainers
+### Removing Inactive Members
 
-An existing Maintainer can be removed from the active list if they are no longer meeting the expectations of the role. If a Maintainer meets one of the following criteria, any other Maintainer can propose their removal through a pull request:
+An existing Member can be removed from the active list if they are no longer meeting the expectations of the role. If a Member meets one of the following criteria, any other Member can propose their removal through a pull request:
 
 - They haven't participated in community activities for more than three months.
 - They have violated the governance rules more than twice.
 
-Once the conditions are confirmed, the Maintainer can be removed, unless they ask to stay and get at least 50% approval from the other Maintainers. If someone is removed, we'll add them to an alumni section in this document to recognize their past contributions.
+Once the conditions are confirmed, the Member can be removed, unless they ask to stay and get at least 50% approval from the other Members. If someone is removed, we'll add them to an alumni section in this document to recognize their past contributions.
+
+## Election Process
+
+The candidates in the election must explain their past contributions to the project and community, as well as their future plans, while also presenting their campaign reasons and clear intentions.
+
+Dragonfly holds regular elections for Maintainer positions to ensure fair selection:
+
+- **Bi-Weekly Meeting Discussion**: Each nomination is discussed in at least one bi-weekly community meeting for feedback and questions.
+- **Nomination Period**: Existing Maintainers nominate candidates via issues, which remain open for at least 7 days.
+- **Voting Period**: Active Maintainers vote on candidates over a 7-day period, with one vote per open position.
+- **Counting and Announcement**: Votes are tallied, and top vote-getters become new Maintainers.
+- **Documentation**: After elections, the results are documented in meeting summaries or official website, and the election issues are closed with appropriate references.
+
+
+### Maximum Representation
+
+To ensure balanced representation, no more than four active Maintainers may be from the same company. If more than four candidates from one company are elected, only the top four vote-getters will serve, with additional slots filled by the next highest vote recipients from other organizations.
+
+### Vacancies
+
+If an elected Maintainer leaves, the candidate with the next most votes from the previous election will be offered the seat. This continues until the seat is filled.
+
+If this fails, a special election will be held using the eligible voters from the most recent election. A Maintainer elected in a special election serves the remainder of the term for the person they're replacing.


### PR DESCRIPTION
- Update contributor ladder with clearer role definitions
- Revise community membership doc for consistency
- Simplify contributing guide for better readability
- Refresh governance doc with concise principles
- Streamline security policy for clarity