### PR TITLE
docs: add meeting skip notice for 2025-08-12 and next meeting info

### DIFF
--- a/meetings/maintainer/2025-08-12/README.md
+++ b/meetings/maintainer/2025-08-12/README.md
@@ -1,0 +1,9 @@
+# Meeting Skip Notice
+
+## Reason for Skipping
+The maintainer meeting scheduled for today has been skipped due to conflicting scheduling commitments from key participants who had other mandatory meetings at the same time slot.
+
+## Next Meeting
+The next maintainer meeting will be held on **August 26, 2025** at the regular time slot, assuming no further conflicts arise. The topics for the next meeting can be found and proposed via the [link](https://github.com/dragonflyoss/community/issues/66).
+
+We apologize for any inconvenience this may cause and look forward to having all maintainers present for our next scheduled session.


### PR DESCRIPTION
This pull request adds a meeting skip notice for the maintainer meeting scheduled on August 12, 2025. The notice explains the reason for skipping and provides details about the next meeting.
