### PR TITLE
docs(meetings): add README for maintainer meeting on 2025-08-26

### DIFF
--- a/meetings/maintainer/2025-08-26/README.md
+++ b/meetings/maintainer/2025-08-26/README.md
@@ -1,0 +1,79 @@
+# Maintainer Meeting
+
+## Attendees
+
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Changfu Zhang](https://github.com/BraveY) (University of Science and Technology Beijing/Nydus)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud)
+- [Yuan Yang](https://github.com/yyzai384) (Alibaba Cloud)
+- [Chaozhi Ma](https://github.com/ClementMaH) (Alibaba Cloud)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation)
+- [Muyu Yang](https://github.com/LunaWhispers) (Ant Group/Dragonfly)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Liu Zhao](https://github.com/BraveY) (Ant Group/Nydus)
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+  /Dragonfly)
+
+## Topics
+
+### IEEE Transactions on Networking: "Empowering Dragonfly: A Lightweight and Scalable Distribution System for Large Models with High Concurrency" @fcgxz2003 @mingcheng
+
+Congratulations to Dr. Zhou Xu(@fcgxz2003) on the acceptance of the paper on Dragonfly scheduling optimization in IEEE ToN, expected to be published in September.
+
+### The progress of Dragonfly Graduation Application. @mingcheng @gaius-qi
+
+Move the graduation application to "TOC DD Evaluation", refer to https://github.com/cncf/toc/issues/1358#issuecomment-3173713783.
+
+### Member Nomination for @Zephyrcf. @BraveY
+
+https://github.com/dragonflyoss/community/issues/69
+
+## Actions
+
+- [ ] Support Model Artifact by OCI Spec in VLLM, and Dragonfly needs to support P2P distribution of Model layers. @CormickKneey
+- [ ] Support Model Artifact by OCI Spec in Fluid, and Dragonfly needs to support P2P distribution of Model layers. @chlins @gaius-qi
+- [ ] The Call for Papers (CFP) for KCD Hangzhou + OpenInfra China Day 2025 is open, refer to https://sessionize.com/kcd-hangzhou-and-oicd-2025/. @mingcheng
+- [ ] After paper publication(IEEE ToN), we need @mingcheng to help with promotion.
+- [x] Complete the final version of the graduation proposal and application document by this Friday. And complete PR review and merge next week. @gaius-qi
+- [x] Update development guidance @CooooolFrog
+
+### Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+### Github Issue
+
+#### TODO
+
+- https://github.com/dragonflyoss/dragonfly/issues/4277 @CooooolFrog
+- https://github.com/dragonflyoss/dragonfly/issues/4276 @ClementMaH
+- https://github.com/dragonflyoss/dragonfly/issues/3165 @yyzai384
+
+#### WIP
+
+- https://github.com/dragonflyoss/dragonfly/issues/4202 @yyzai384
+- https://github.com/dragonflyoss/dragonfly/issues/4195 @chlins
+- https://github.com/dragonflyoss/helm-charts/issues/363 @chlins
+- https://github.com/dragonflyoss/helm-charts/issues/387 @imeoer
+- https://github.com/dragonflyoss/dragonfly/issues/3733 @chlins
+- https://github.com/dragonflyoss/nydus/issues/1715 @Zephyrcf
+- https://github.com/dragonflyoss/dragonfly/issues/4204 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/4280 @yxxhero
+- https://github.com/dragonflyoss/dragonfly/issues/4027 @fu220 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/4026 @LunaWhispers
+- https://github.com/dragonflyoss/nydus/issues/1735 @Zephyrcf
+- https://github.com/dragonflyoss/nydus/issues/1445 @BraveY
+- https://github.com/dragonflyoss/nydus/issues/1692 @imeoer
+- https://github.com/dragonflyoss/nydus/issues/1657 @BraveY
+
+#### Done
+
+- https://github.com/dragonflyoss/nydus/issues/1720 @BraveY
+- https://github.com/dragonflyoss/nydus/issues/1725 @BraveY
+- https://github.com/dragonflyoss/dragonfly/issues/4211 @[CooooolFrog](https://github.com/CooooolFrog)
+- https://github.com/dragonflyoss/client/issues/1238 @chlins
+- https://github.com/dragonflyoss/client/issues/1239 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/4221 @gaius-qi
+- https://github.com/dragonflyoss/dragonfly/issues/4216 @chlins
+- https://github.com/dragonflyoss/dragonfly/issues/4217 @chlins


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds detailed meeting notes for the maintainer meeting scheduled on August 26, 2025. The new document records attendees, discussion topics, action items, and the status of various community issues and tasks.

Key additions include:

Meeting documentation:

* Created a new `README.md` file for the 2025-08-26 maintainer meeting, listing all attendees and their affiliations.
* Documented major discussion topics, including the acceptance of a Dragonfly-related paper in IEEE Transactions on Networking, progress on the Dragonfly graduation application, and a member nomination.

Action items and community tracking:

* Outlined specific action items with assigned owners and deadlines, covering tasks such as finalizing the graduation proposal, supporting Model Artifact by OCI Spec, updating development guidance, and conference promotion.
* Added sections to track the status of GitHub issues relevant to the community, categorized as TODO, WIP (work in progress), and Done, with responsible contributors noted.
<!--- Describe your changes in detail -->

## Related Issue
Closed https://github.com/dragonflyoss/community/issues/66.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
