### PR TITLE
docs(meetings): update promotional tasks in README

### DIFF
--- a/meetings/maintainer/2025-08-26/README.md
+++ b/meetings/maintainer/2025-08-26/README.md
@@ -34,7 +34,8 @@ https://github.com/dragonflyoss/community/issues/69
 - [ ] Support Model Artifact by OCI Spec in VLLM, and Dragonfly needs to support P2P distribution of Model layers. @CormickKneey
 - [ ] Support Model Artifact by OCI Spec in Fluid, and Dragonfly needs to support P2P distribution of Model layers. @chlins @gaius-qi
 - [ ] The Call for Papers (CFP) for KCD Hangzhou + OpenInfra China Day 2025 is open, refer to https://sessionize.com/kcd-hangzhou-and-oicd-2025/. @mingcheng
-- [ ] After paper publication(IEEE ToN), we need @mingcheng to help with promotion.
+- [ ] Write an promotional article about a paper, including a brief overview of the paper's content. Publish the article to d7y.io. @fcgxz2003
+- [ ] After the promotional article for the paper is completed by @fcgxz2003, publish it on various promotion channels. @mingcheng
 - [x] Complete the final version of the graduation proposal and application document by this Friday. And complete PR review and merge next week. @gaius-qi
 - [x] Update development guidance @CooooolFrog
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the meeting agenda for the maintainer meeting on August 26, 2025, by refining the action items related to paper promotion. The changes clarify responsibilities and break down the promotion process into two distinct tasks.

Updates to meeting action items:

* Replaced the generic task about post-publication paper promotion with two specific tasks: one for writing a promotional article about the paper and publishing it to `d7y.io`, and another for further promoting the article across various channels.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
