### PR TITLE
feat: add GitVote configuration file

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -25,8 +25,8 @@
 #         - "*.txt"
 #       profile: default
 #
-automation:
-  enabled: false
+# automation:
+#   enabled: false
 
 # Configuration profiles (required)
 #
@@ -168,6 +168,6 @@ profiles:
     #   discussions:
     #     category: announcements
     #
-    announcements:
-      discussions:
-        category: announcements
+    # announcements:
+    #   discussions:
+    #     category: announcements

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -38,6 +38,8 @@ profiles:
   # Default configuration profile
   #
   # This profile will be used with votes created with the /vote command
+  #
+  # The default election role for Dragonfly project is member.
   default:
     # Voting duration (required)
     #
@@ -50,7 +52,7 @@ profiles:
     #   days    | day    | d
     #   weeks   | week   | w
     #
-    duration: 2w
+    duration: 7d
 
     # Pass threshold (required)
     #
@@ -91,8 +93,6 @@ profiles:
       teams:
         - dragonfly-approvers
         - dragonfly-maintainers
-        - nydus-maintainers
-        - nydus-reviewers
       users:
         - gaius-qi
         - mingcheng
@@ -125,7 +125,7 @@ profiles:
     #
     # periodic_status_check: "5 days"
     #
-    periodic_status_check: "5 days"
+    periodic_status_check: "3 days"
 
     # Close on passing
     #
@@ -171,3 +171,31 @@ profiles:
     # announcements:
     #   discussions:
     #     category: announcements
+
+  # /vote-member
+  member:
+    duration: 7d
+    pass_threshold: 50
+    allowed_voters:
+      teams:
+        - dragonfly-approvers
+        - dragonfly-maintainers
+    close_on_passing: true
+
+  # /vote-approver
+  approver:
+    duration: 14d
+    pass_threshold: 50
+    allowed_voters:
+      teams:
+        - dragonfly-maintainers
+    close_on_passing: true
+
+  # /vote-maintainer
+  maintainer:
+    duration: 14d
+    pass_threshold: 65
+    allowed_voters:
+      teams:
+        - dragonfly-maintainers
+    close_on_passing: true

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,173 @@
+# GitVote configuration file
+#
+# GitVote will look for it in the following locations (in order of precedence):
+#
+#   - At the root of the repository where the vote was created
+#   - At the root of the .github repository, for organization wide configuration
+#
+
+# Automation (optional)
+#
+# Create votes automatically on PRs when any of the files affected by the PR
+# match any of the patterns provided. Patterns must follow the gitignore
+# format (https://git-scm.com/docs/gitignore#_pattern_format).
+#
+# Each automation rule must include a list of patterns and the profile to use
+# when creating the vote. This allows creating votes automatically using the
+# desired configuration based on the patterns matched. Rules are processed in
+# the order provided, and the first match wins.
+#
+# automation:
+#   enabled: true
+#   rules:
+#     - patterns:
+#         - "README.md"
+#         - "*.txt"
+#       profile: default
+#
+automation:
+  enabled: false
+
+# Configuration profiles (required)
+#
+# A configuration profile defines some properties of a vote, like its duration,
+# the pass threshold or the users who have a binding vote. It's possible to
+# define multiple configuration profiles, each with a different set of settings.
+#
+profiles:
+  # Default configuration profile
+  #
+  # This profile will be used with votes created with the /vote command
+  default:
+    # Voting duration (required)
+    #
+    # How long the vote will be open
+    #
+    # Units supported (can be combined as in 1hour 30mins):
+    #
+    #   minutes | minute | mins | min | m
+    #   hours   | hour   | hrs  | hrs | h
+    #   days    | day    | d
+    #   weeks   | week   | w
+    #
+    duration: 2w
+
+    # Pass threshold (required)
+    #
+    # Percentage of votes in favor required to pass the vote
+    #
+    # The percentage is calculated based on the number of votes in favor and the
+    # number of allowed voters (see allowed_voters field below for more details).
+    pass_threshold: 50
+
+    # Allowed voters (optional)
+    #
+    # List of GitHub teams and users who have binding votes
+    #
+    # If no teams or users are provided, all repository collaborators will be
+    # allowed to vote. For organization-owned repositories, the list of
+    # collaborators includes outside collaborators, organization members that
+    # are direct collaborators, organization members with access through team
+    # memberships, organization members with access through default organization
+    # permissions, and organization owners.
+    #
+    # By default, teams' members with the maintainer role are allowed to vote
+    # as well. By using the `exclude_team_maintainers` option, it's possible to
+    # modify this behavior so that only teams' members with the member role are
+    # considered allowed voters. Please note that this option only applies to
+    # the teams explicitly listed in `allowed_voters/teams`.
+    #
+    # Teams names must be provided without the organization prefix.
+    #
+    # allowed_voters:
+    #   teams:
+    #     - team1
+    #   users:
+    #     - cynthia-sg
+    #     - tegioz
+    #   exclude_team_maintainers: false
+    #
+    allowed_voters:
+      teams:
+        - dragonfly-approvers
+        - dragonfly-maintainers
+        - nydus-maintainers
+        - nydus-reviewers
+      users:
+        - gaius-qi
+        - mingcheng
+      exclude_team_maintainers: false
+
+    # Periodic status check
+    #
+    # GitVote allows checking the status of a vote in progress manually by
+    # calling the /check-vote command. The periodic status check option makes
+    # it possible to automate the execution of status checks periodically. The
+    # vote status will be published to the corresponding issue or pull request,
+    # the same way as if the /check-vote command would have been called
+    # manually.
+    #
+    # When this option is enabled, while the vote is open, a status check will
+    # be run automatically using the frequency configured. Please note that the
+    # hard limit of one status check per day still applies, so if the command
+    # has been called manually the automatic periodic run may be delayed.
+    # Automatic status checks won't be run if the vote will be closed within
+    # the next hour.
+    #
+    # Units supported:
+    #
+    #   - day / days
+    #   - week / weeks
+    #
+    # As an example, using a value of "5 days" would mean that 5 days after the
+    # vote was created, and every 5 days after that, an automatic status check
+    # will be run.
+    #
+    # periodic_status_check: "5 days"
+    #
+    periodic_status_check: "5 days"
+
+    # Close on passing
+    #
+    # By default, votes remain open for the configured duration. Sometimes,
+    # specially on votes that stay open for a long time, it may be preferable
+    # to close a vote automatically once the passing threshold has been met.
+    # The close on passing feature makes this possible. Open votes where this
+    # feature has been enabled will be checked once daily and, if GitVote
+    # detects that the vote has passed, it will automatically close it.
+    #
+    # close_on_passing: true
+    #
+    close_on_passing: true
+
+    # Close on passing minimum wait
+    #
+    # When the close on passing feature is activated, voting will conclude once
+    # the pass threshold is met. However, there may be instances where it is
+    # preferable to implement a minimum wait time, even if the vote would
+    # already pass. This allows participants sufficient opportunity to engage
+    # and reflect before the vote is automatically finalized.
+    #
+    # Units supported:
+    #
+    #   - day / days
+    #   - week / weeks
+    #
+    # close_on_passing_min_wait: "1 week"
+    #
+    close_on_passing_min_wait: null
+
+    # Announcements
+    #
+    # GitVote can announce the results of a vote when it is closed on GitHub
+    # discussions. This feature won't be enabled if this configuration section
+    # is not provided. The slug of the category where the announcement will be
+    # posted to must be specified (i.e. announcements).
+    #
+    # announcements:
+    #   discussions:
+    #     category: announcements
+    #
+    announcements:
+      discussions:
+        category: announcements

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -8,6 +8,7 @@
 - [Election Process](#election-process)
   - [Maximum Representation](#maximum-representation)
   - [Vacancies](#vacancies)
+  - [Demonstrating: Adding a New Member](#demonstrating-adding-a-new-member)
 
 As a proud member of the CNCF, the Dragonfly project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
@@ -88,20 +89,20 @@ The candidates in the election must explain their past contributions to the proj
 
 Dragonfly holds below elections for the specific roles:
 
-| Role       | Nomination Period | Voting Period   | Eligible Voters                   | Voting Requirements |
-| ---------- | ----------------- | --------------- | --------------------------------- | ------------------- |
-| Member     | 7 days minimum    | 7 days          | Current Maintainers and Approvers | Simple majority     |
-| Approver   | 7 days minimum    | 14 days minimum | Current Maintainers only          | Simple majority     |
-| Maintainer | 7 days minimum    | 14 days minimum | Current Maintainers only          | Supermajority       |
+| Role       | Nomination Period | Voting Period | Eligible Voters                   | Voting Requirements |
+| ---------- | ----------------- | ------------- | --------------------------------- | ------------------- |
+| Member     | 7 days            | 7 days        | Current Maintainers and Approvers | Simple majority     |
+| Approver   | 7 days            | 14 days       | Current Maintainers only          | Simple majority     |
+| Maintainer | 7 days            | 14 days       | Current Maintainers only          | Supermajority       |
 
 
-- **Nomination Period**: Nominees are introduced during bi-weekly community meetings with an overview of their contributions. Following the meeting, nominees create an issue that remains open for at least 7 days to allow community discussion.
+- **Nomination Period**: Nominees are introduced during bi-weekly community meetings with an overview of their contributions. Following the meeting, nominees create an issue that remains open for 7 days to allow community discussion.
 
 - **Discussion Phase**: Each nomination is reviewed in at least one bi-weekly community meeting where members can provide feedback and ask questions about the candidate's qualifications.
 
 - **Voting Period**:
   - Member elections: 7 days
-  - Approver or Maintainer elections: 14 days minimum
+  - Approver or Maintainer elections: 14 days
 
 - **Voting Eligibility**:
   - For Member: Current Maintainers and Approvers may vote
@@ -123,3 +124,38 @@ To ensure balanced representation, no more than four active Maintainers may be f
 If an elected Maintainer leaves, the candidate with the next most votes from the previous election will be offered the seat. This continues until the seat is filled.
 
 If this fails, a special election will be held using the eligible voters from the most recent election. A Maintainer elected in a special election serves the remainder of the term for the person they're replacing.
+
+
+### Demonstrating: Adding a New Member
+
+**Background**: Jane Doe has been contributing to the Dragonfly project for 3 months, consistently submitting bug fixes, documentation improvements, and participating in community discussions.
+
+**Step 1: Nomination**
+- Existing Maintainer John Smith opens an issue titled "Nomination: Jane Doe for Member"
+- The issue includes:
+  - Jane's GitHub handle and contact information
+  - Summary of her contributions over the past 3 months
+  - Links to her pull requests and issue discussions
+  - Justification for why she should become a Member
+
+**Step 2: Community Discussion**
+- The nomination issue remains open for 7 days
+- Community members provide feedback and ask questions
+- Jane responds to questions about her commitment and future plans
+- The nomination is discussed during the next bi-weekly community meeting
+
+**Step 3: Voting Process**
+- After the discussion period, eligible voters (current Maintainers and Approvers) cast their votes
+- Voting takes place for 7 days using GitHub issue reactions (thumbs up for yes, thumbs down for no, and eyes for abstain). We are using [gitvote](https://github.com/cncf/gitvote) automated vote counting.
+- Simple majority (>50%) is required for approval
+
+**Step 4: Results and Onboarding**
+- Vote results are announced: 5 yes, 1 no, 1 abstain (71% approval - passes)
+- Jane is officially welcomed as a new Dragonfly Community Member
+- She is added to the GitHub organization with appropriate permissions
+- Her information is updated in the `MEMBERS.md` file by the Maintainers Team
+- A welcome message is posted in the next community meeting summary
+
+
+
+

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -2,8 +2,8 @@
 
 - [How We Make Decisions](#how-we-make-decisions)
 - [Managing Membership](#managing-membership)
-  - [Adding New Members](#adding-new-members)
-  - [Removing Inactive Members](#removing-inactive-members)
+  - [Adding New Member/Approver/Maintainer](#adding-new-memberapprovermaintainer)
+  - [Removing Inactive Member/Approver/Maintainer](#removing-inactive-memberapprovermaintainer)
   - [Voluntary Departure](#voluntary-departure)
 - [Election Process](#election-process)
   - [Maximum Representation](#maximum-representation)
@@ -86,13 +86,33 @@ After the departure date, the Member and their GitHub ID will be moved to the em
 
 The candidates in the election must explain their past contributions to the project and community, as well as their future plans, while also presenting their campaign reasons and clear intentions.
 
-Dragonfly holds regular elections for Maintainer positions to ensure fair selection:
+Dragonfly holds below elections for the specific roles:
 
-- **Bi-Weekly Meeting Discussion**: Each nomination is discussed in at least one bi-weekly community meeting for feedback and questions.
-- **Nomination Period**: Existing Maintainers nominate candidates via issues, which remain open for at least 7 days.
-- **Voting Period**: Active Maintainers vote on candidates over a 7-day period, with one vote per open position.
-- **Counting and Announcement**: Votes are tallied, and top vote-getters become new Maintainers.
-- **Documentation**: After elections, the results are documented in meeting summaries or official website, and the election issues are closed with appropriate references.
+| Role       | Nomination Period | Voting Period   | Eligible Voters                   | Voting Requirements |
+| ---------- | ----------------- | --------------- | --------------------------------- | ------------------- |
+| Member     | 7 days minimum    | 7 days          | Current Maintainers and Approvers | Simple majority     |
+| Approver   | 7 days minimum    | 14 days minimum | Current Maintainers only          | Simple majority     |
+| Maintainer | 7 days minimum    | 14 days minimum | Current Maintainers only          | Supermajority       |
+
+
+- **Nomination Period**: Nominees are introduced during bi-weekly community meetings with an overview of their contributions. Following the meeting, nominees create an issue that remains open for at least 7 days to allow community discussion.
+
+- **Discussion Phase**: Each nomination is reviewed in at least one bi-weekly community meeting where members can provide feedback and ask questions about the candidate's qualifications.
+
+- **Voting Period**:
+  - Member elections: 7 days
+  - Approver or Maintainer elections: 14 days minimum
+
+- **Voting Eligibility**:
+  - For Member: Current Maintainers and Approvers may vote
+  - For Approver or Maintainer: Only current Maintainers may vote
+
+- **Voting Requirements**:
+  - For Member: Simple majority (>50%) of eligible voters required to pass
+  - For Approver: Simple majority (≥50%) of current Maintainers required to pass
+  - For Maintainer: Supermajority (≥65%) of current Maintainers required to pass
+
+- **Results and Implementation**: Votes are counted and the highest vote recipients are selected for the respective roles. Election outcomes are documented in meeting summaries, and new nominee will added to the GitHub Organization by the Maintainers Team.
 
 ### Maximum Representation
 


### PR DESCRIPTION
- Introduce .gitvote.yml for automated voting on PRs
- Set default voting duration to 2 weeks
- Define pass threshold at 50% for votes
- Specify allowed voters from specific teams and users
- Enable periodic status checks and close on passing features

https://github.com/cncf/gitvote?tab=readme-ov-file#configuration