### PR TITLE
docs: refine role references across several documents

### DIFF
--- a/roles/Community-Managers.md
+++ b/roles/Community-Managers.md
@@ -1,5 +1,17 @@
 # Community Managers
 
-The Community Managers requirements and responsibilities are listed in [COMMUNITY_MEMBERSHIP.md](https://github.com/dragonflyoss/community/blob/master/COMMUNITY_MEMBERSHIP.md#community-manager). The following are the current community managers:
+The Community Managers requirements and responsibilities are listed in [COMMUNITY_MEMBERSHIP.md](https://github.com/dragonflyoss/community/blob/master/COMMUNITY_MEMBERSHIP.md#community-manager). 
 
-Please refer to: [dragonfly/OWNERS.md](https://github.com/dragonflyoss/dragonfly/blob/main/OWNERS.md).
+They are also expected to follow the guidelines below:
+
+- See [GOVERNANCE.md](../GOVERNANCE.md) that describes governance guidelines and maintainer responsibilities..
+- See [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) about contributors and maintainers standards in the community.
+- See [CONTRIBUTING.md](../CONTRIBUTING.md) for general contributing guidelines.
+
+## Maintainers
+
+For the list of current maintainers, please refer to our [community maintainers](../MAINTAINERS.md).
+
+## Emeritus maintainers
+
+And for the list of emeritus maintainers, please refer to our [community emeritus maintainers](../MAINTAINERS.md#emeritus-maintainers).

--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -1,11 +1,5 @@
-# Maintainers
+## Project Maintainers
 
-The Maintainers requirements and responsibilities are listed in [COMMUNITY_MEMBERSHIP.md](https://github.com/dragonflyoss/community/blob/master/COMMUNITY_MEMBERSHIP.md#maintainer). The following are the current maintainers:
+The Maintainers requirements and responsibilities are listed in [COMMUNITY_MEMBERSHIP.md](../COMMUNITY_MEMBERSHIP.md#maintainer). The following are the current maintainers:
 
-## Dragonfly-maintainers: Maintainers of [dragonflyoss/dragonfly](https://github.com/dragonflyoss/dragonfly/tree/main)
-
-Please refer to: [dragonfly/MAINTAINERS.md](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md).
-
-## Nydus-maintainers: Maintainers of [dragonflyoss/nydus](https://github.com/dragonflyoss/nydus)
-
-Please refer to: [nydus/MAINTAINERS.md](https://github.com/dragonflyoss/nydus/blob/master/MAINTAINERS.md).
+Dragonfly Project Maintainers's list can be found in the [community/MAINTAINERS.md](../MAINTAINERS.md). And for the Nydus Maintainers's list, please refer to: [nydus/MAINTAINERS.md](https://github.com/dragonflyoss/nydus/blob/master/MAINTAINERS.md).

--- a/roles/Security-Team.md
+++ b/roles/Security-Team.md
@@ -1,5 +1,5 @@
 # Security Team
 
-For the security policy of the security team, please refer to: [SECURITY.md](https://github.com/dragonflyoss/community/blob/master/SECURITY.md#security-response-team).
+For the security policy of the security team, please refer to: [SECURITY.md](../SECURITY.md#security-response-team). 
 
-For the current security team members, please refer to: [MAINTAINERS.md](https://github.com/dragonflyoss/dragonfly/blob/main/MAINTAINERS.md).
+And for the current security team members, please refer to: [MAINTAINERS.md](../MAINTAINERS.md).


### PR DESCRIPTION
## Description

- Update `Community-Managers.md` to point to `OWNERS.md`
- Clarify `Maintainers.md` by linking to project-specific `MAINTAINERS.md`
- Adjust `Security-Team.md` to reference `MAINTAINERS.md` within community repo
- Improve consistency in internal document linking