### PR TITLE
docs: update community docs with subproject references

### DIFF
--- a/COMMUNITY_LADDER.md
+++ b/COMMUNITY_LADDER.md
@@ -27,7 +27,7 @@ We've put this document together with a few key goals in mind:
 
 ## Scope
 
-This guide covers the roles and responsibilities for everyone who contributes to the Dragonfly open source project. Whether you're writing code, improving documentation, creating tests, or helping in other ways, this is for you.
+This guide covers the roles and responsibilities for everyone who contributes to the Dragonfly open source project and its subprojects and libraries. Whether you're writing code, improving documentation, creating tests, or helping in other ways, this is for you.
 
 The roles of Organization Member, Approver, or Maintainer are officially defined in the [Dragonfly Governance](./GOVERNANCE.md) document.
 

--- a/COMMUNITY_MEMBERSHIP.md
+++ b/COMMUNITY_MEMBERSHIP.md
@@ -15,7 +15,7 @@
 
 As a proud member of the CNCF, the Dragonfly project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
-This document explains the responsibilities that come with different contributor roles in the Dragonfly community. Our project is organized into several sub-projects, including (but not limited to) nydus, nydus-snapshotter, api, docs, console, and client. The responsibilities for each role are tied to these specific sub-projects and their repositories.
+This document explains the responsibilities that come with different contributor roles in the Dragonfly community. Our project is organized into several sub-projects and libraries, including (but not limited to) [nydus](https://github.com/dragonflyoss/nydus), [api](https://github.com/dragonflyoss/api), [console](https://github.com/dragonflyoss/console), and [client](https://github.com/dragonflyoss/client). The responsibilities for each role are tied to these specific sub-projects and their repositories.
 
 For a full breakdown of the roles, responsibilities, and qualifications for our community members, please check out our [Contributor Ladder](COMMUNITY_LADDER.md).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,6 +9,12 @@ Welcome to the Dragonfly project's governance guide! We believe in open and tran
 - **Neutrality**: As a community-driven project, our decisions are based on technical merit and community consensus, free from the influence of any single company or individual.
 - **Simplicity**: We keep our governance processes as straightforward as possible, avoiding unnecessary red tape.
 
+## Scope
+
+This governance document applies to the Dragonfly project and all its subprojects or libraries, including but not limited to [Nydus](https://github.com/dragonflyoss/nydus), nydus-snapshotter, api, docs, console, and client.
+
+These subprojects and libraries may have their own maintainers and contributors, but they all adhere to the overarching principles and practices established by the Dragonfly community.
+
 ## Roles and Responsibilities
 
 For a detailed look at the different roles in our community and what they involve, please see our [Dragonfly Contributor Ladder](COMMUNITY_LADDER.md).

--- a/roles/README.md
+++ b/roles/README.md
@@ -1,0 +1,47 @@
+# Dragonfly Community Roles
+
+This directory contains information about the various roles and membership levels within the Dragonfly community. Our community follows a structured approach to governance and participation, with different levels of responsibility and access.
+
+## Role Definitions
+
+The Dragonfly community has several membership levels, each with specific responsibilities and privileges:
+
+### [Members](Members.md)
+
+Community members who have made sustained contributions to the project and are committed to its continued development.
+
+### [Approvers](Approvers.md)
+
+Contributors who have the ability to approve pull requests and are responsible for maintaining code quality in specific areas.
+
+### [Maintainers](Maintainers.md)
+
+Senior contributors who have overall responsibility for the project direction, architecture decisions, and community governance.
+
+### [Security Team](Security-Team.md)
+
+Dedicated team members responsible for handling security issues, vulnerability reports, and security-related communications.
+
+## Getting Involved
+
+If you're interested in contributing to Dragonfly and potentially taking on a community role, please:
+
+1. Start by reading our [Community Membership](../COMMUNITY_MEMBERSHIP.md) guidelines
+2. Review the [Community Ladder](../COMMUNITY_LADDER.md) to understand progression paths
+3. Check out our [Contributing Guidelines](../CONTRIBUTING.md)
+4. Join our community discussions and start contributing!
+
+## Governance
+
+For information about how decisions are made in the Dragonfly community, please refer to our [Governance](../GOVERNANCE.md) document.
+
+## Subprojects
+
+The Dragonfly community also manages several subprojects, each with the same governance and contribution guidelines as Dragonfly itself.
+
+These subprojects may have their own maintainers and contributors, but they all adhere to the overarching principles and practices established by the Dragonfly community.
+
+### [Nydus](https://github.com/dragonflyoss/nydus)
+
+The Dragonfly image service, providing fast, secure and easy access to container images. Current Maintainers of Nydus was located in the [Nydus GitHub repository](https://github.com/dragonflyoss/nydus/blob/master/MAINTAINERS.md).
+  


### PR DESCRIPTION
## Description

- Add links to Nydus subproject in governance and membership docs
- Expand scope in COMMUNITY_LADDER.md to include subprojects
- Create roles directory with detailed README for community roles

## Related Issue

https://github.com/dragonflyoss/community/issues/90