### PR TITLE
docs(README): update GitHub Discussions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the [Google Calendar](https://calendar.google.com/calendar/embed?src=46bc5a3d67a
 Join the conversation and help the community grow. Here are the ways to get involved:
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Github Discussions**: [Dragonfly Discussion Forum][discussion]
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
 - **Mailing Lists**:
   - **Developers**: <dragonfly-developers@googlegroups.com>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes a minor update to the `README.md` file, improving the link to the Dragonfly Discussion Forum on GitHub Discussions. The change replaces the reference-style link with a direct URL for clarity and accessibility.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/4425
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
