### PR TITLE
docs(members): add new community members

### DIFF
--- a/roles/Members.md
+++ b/roles/Members.md
@@ -13,6 +13,10 @@ This document lists all current members of the Dragonfly community, along with t
 |        [ftljk](https://github.com/ftljk)        |  Tianlan Fan  | qdbjoftljk@gmail.com |        Harbin Institute of Technology         |
 |     [BruceAko](https://github.com/BruceAko)     | Chongzhi Deng | chongzhi@hust.edu.cn | Huazhong University of Science and Technology |
 |  [CooooolFrog](https://github.com/CooooolFrog)  |  ZuLiangWang  | coolfrog@apache.org  |                 Alibaba Cloud                 |
+|   [jjzhang332](https://github.com/jjzhang332)   |  Lujia Zhang  |  2682950039@qq.com   |                   Ant Group                   |
+|        [fu220](https://github.com/fu220)        |   Jinyu Fu    |  2863318196@qq.com   |           Xi'an Jiaotong University           |
+|     [EvanCley](https://github.com/EvanCley)     |   Yifan Cao   | caoyifan1a2b@163.com |                 Alibaba Cloud                 |
+
 
 <!-- markdownlint-restore -->
 


### PR DESCRIPTION
## Description

- Add Chongzhi Deng (BruceAko) with affiliation to Huazhong University of Science and Technology
- Add ZuLiangWang (CooooolFrog) with affiliation to Alibaba Cloud
- Ensure consistent table formatting for member entries

## Related Issue

- https://github.com/dragonflyoss/community/issues/120
- https://github.com/dragonflyoss/community/issues/121
- https://github.com/dragonflyoss/community/issues/123
