### PR TITLE
docs(maintainers): move maintainers to emeritus

### DIFF
--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -4,20 +4,18 @@ This document lists the current maintainers of the Dragonfly community. The list
 
 <!-- markdownlint-disable -->
 
-|                    GitHub ID                    |     Name     |            Email             |             Company             |
-| :---------------------------------------------: | :----------: | :--------------------------: | :-----------------------------: |
-|   [allencloud](https://github.com/allencloud)   |  Allen Sun   |    shlallen1990@gmail.com    |          Alibaba Group          |
-|       [chlins](https://github.com/chlins)       | Chlins Zhang |    chlins.zhang@gmail.com    |            Ant Group            |
-|    [fcgxz2003](https://github.com/fcgxz2003)    |  fcgxz2003   |       834756128@qq.com       | Dalian University of Technology |
-|     [gaius-qi](https://github.com/gaius-qi)     |   Gaius Qi   |      gaius.qi@gmail.com      |            Ant Group            |
-| [CormickKneey](https://github.com/CormickKneey) |  Han Jiang   |    cormick1080@gmail.com     |            Kuaishou             |
-|       [jim3ma](https://github.com/jim3ma)       |    Jim Ma    |     majinjing3@gmail.com     |            Ant Group            |
-|    [mingcheng](https://github.com/mingcheng)    |  mingcheng   |     mingcheng@apache.org     |        Apache Foundation        |
-|     [bergwolf](https://github.com/bergwolf)     |   Peng Tao   |      bergwolf@hyper.sh       |            Ant Group            |
-|      [yxxhero](https://github.com/yxxhero)      |   yxxhero    |      aiopsclub@163.com       |            Zhipu AI             |
-|      [hyy0322](https://github.com/hyy0322)      | Yiyang Huang |       691795636@qq.com       |            ByteDance            |
-|     [yyzai384](https://github.com/yyzai384)     |  Yuan Yang   |   qiguo.yy@alibaba-inc.com   |          Alibaba Group          |
-|  [garfield009](https://github.com/garfield009)  | Zuozheng Hu  | zuozheng.hzz@alibaba-inc.com |          Alibaba Group          |
+|                    GitHub ID                    |     Name     |          Email           |             Company             |
+| :---------------------------------------------: | :----------: | :----------------------: | :-----------------------------: |
+|       [chlins](https://github.com/chlins)       | Chlins Zhang |  chlins.zhang@gmail.com  |            Ant Group            |
+|    [fcgxz2003](https://github.com/fcgxz2003)    |  fcgxz2003   |     834756128@qq.com     | Dalian University of Technology |
+|     [gaius-qi](https://github.com/gaius-qi)     |   Gaius Qi   |    gaius.qi@gmail.com    |            Ant Group            |
+| [CormickKneey](https://github.com/CormickKneey) |  Han Jiang   |  cormick1080@gmail.com   |            Kuaishou             |
+|       [jim3ma](https://github.com/jim3ma)       |    Jim Ma    |   majinjing3@gmail.com   |            Ant Group            |
+|    [mingcheng](https://github.com/mingcheng)    |  mingcheng   |   mingcheng@apache.org   |        Apache Foundation        |
+|     [bergwolf](https://github.com/bergwolf)     |   Peng Tao   |    bergwolf@hyper.sh     |            Ant Group            |
+|      [yxxhero](https://github.com/yxxhero)      |   yxxhero    |    aiopsclub@163.com     |            Zhipu AI             |
+|      [hyy0322](https://github.com/hyy0322)      | Yiyang Huang |     691795636@qq.com     |            ByteDance            |
+|     [yyzai384](https://github.com/yyzai384)     |  Yuan Yang   | qiguo.yy@alibaba-inc.com |          Alibaba Group          |
 
 <!-- markdownlint-restore -->
 
@@ -31,6 +29,7 @@ Below is the list of emeritus (retired) maintainers. Thank them for their contri
 
 |                      GitHub ID                      |      Name       |            Email             |    Company    |
 | :-------------------------------------------------: | :-------------: | :--------------------------: | :-----------: |
+|     [allencloud](https://github.com/allencloud)     |    Allen Sun    |    shlallen1990@gmail.com    | Alibaba Group |
 |   [chenchaobing](https://github.com/chenchaobing)   | Chen, Chaobing  |     chenchaobing@126.com     |     Meitu     |
 |       [bigerous](https://github.com/bigerous)       |   Cui, Dajun    | cuidajun.cdj@alibaba-inc.com | Alibaba Group |
 |        [inoc603](https://github.com/inoc603)        |  Huang, Eddie   |      inoc603@gmail.com       |   ByteDance   |
@@ -41,5 +40,6 @@ Below is the list of emeritus (retired) maintainers. Thank them for their contri
 | [zhouhaibing089](https://github.com/zhouhaibing089) |  Zhou, Haibing  |   zhouhaibing089@gmail.com   |     eBay      |
 |        [mfarooq](https://github.com/mfarooq)        | Mohammed Farooq |     mfarooq.ta@gmail.com     |     Intel     |
 |        [akashhr](https://github.com/akashhr)        |    Akash HR     |    akashhr2021@gmail.com     |     Intel     |
+|    [garfield009](https://github.com/garfield009)    |   Zuozheng Hu   | zuozheng.hzz@alibaba-inc.com | Alibaba Group |
 
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## Description

- Move Allen Sun (allencloud) from active to emeritus maintainers
- Move Zuozheng Hu (garfield009) from active to emeritus maintainers
- Adjust table column widths for consistent formatting

## Related Issue

https://github.com/dragonflyoss/community/issues/131
https://github.com/dragonflyoss/community/issues/132
