### PR TITLE
docs(meeting): add maintainer meeting on 2026-01-13

### DIFF
--- a/meetings/maintainer/2026-01-13/README.md
+++ b/meetings/maintainer/2026-01-13/README.md
@@ -1,0 +1,97 @@
+# Dragonfly Community Meeting 2026-01-13
+
+## Attendees
+
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Jiale Yang](https://github.com/Yang1998-jiale) (Digital Engine)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud)
+- [Yuan Yang](https://github.com/yyzai384) (Alibaba Cloud)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Changfu Zhang](https://github.com/Zephyrcf) (University of Science and Technology Beijing/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+
+## Topics
+
+- 2025 Summary Report @mingcheng
+- 2026 Dragonfly Project Develop Plan and Roadmap @gaius-qi
+- Unfixed issues review and assignment.
+
+## Actions
+
+- [ ] Organize topics and attendees for KubeCon 2026 EU. @mingcheng
+- [ ] Dragonfly graduation announcement (pending CNCF release). @gaius-qi @yyzai384 @CooooolFrog
+- [x] CNCF agreement signing. @yyzai384
+- [x] Inactive Maintainer is removed from the Maintainer List. @mingcheng
+- [x] The Maintainer List were updated on the CNCF Official Repository. @mingcheng
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+None
+
+## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+### TODO
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4499> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4473> @EvanCley
+- <https://github.com/dragonflyoss/dragonfly/issues/4422> @mdxabu
+- <https://github.com/dragonflyoss/dragonfly/issues/4421>
+- <https://github.com/dragonflyoss/dragonfly/issues/4420>
+- <https://github.com/dragonflyoss/dragonfly/issues/4419>
+- <https://github.com/dragonflyoss/dragonfly/issues/4417> @sabarixr
+- <https://github.com/dragonflyoss/dragonfly/issues/4416> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4415> @Jkhall81
+- [containerd/nydus-snapshotter#690](https://github.com/containerd/nydus-snapshotter/issues/690) @imeoer
+
+### WIP
+
+#### Dragonfly
+
+The below issues are discussed and assigned during the meeting:
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4550> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4537> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4541> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4538> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4526> @EvanCley
+- <https://github.com/dragonflyoss/dragonfly/issues/4379> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4362> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4027> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4026> @LunaWhispers
+- <https://github.com/dragonflyoss/dragonfly/issues/4025> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/3713> @baowj-678
+- <https://github.com/dragonflyoss/dragonfly/issues/4413> @fcgxz2003
+
+#### Dragonfly Client
+
+- <https://github.com/dragonflyoss/client/issues/1594> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1561> @pirDOL
+- <https://github.com/dragonflyoss/client/issues/1560> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1559> @CooooolFrog
+- <https://github.com/dragonflyoss/client/issues/1547> @chlins
+- <https://github.com/dragonflyoss/client/issues/1544> @EvanCley
+
+#### Nydus
+
+- <https://github.com/dragonflyoss/nydus/issues/1820> @bergwolf
+- <https://github.com/dragonflyoss/nydus/issues/1827> @imeoer
+- <https://github.com/dragonflyoss/nydus/issues/1826> @bergwolf
+- <https://github.com/dragonflyoss/nydus/issues/1818> @fatelei # This issues is out of date, so need generate new pull request after discussion
+- <https://github.com/dragonflyoss/nydus/issues/1779> @imeoer @BraveY
+- <https://github.com/dragonflyoss/nydus/issues/1808> @BraveY
+
+### Done
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4522>
+- <https://github.com/dragonflyoss/dragonfly/issues/4364> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4302> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4195> @fcgxz2003
+- <https://github.com/dragonflyoss/nydus/issues/1778> @imeoer @BraveY
+- <https://github.com/dragonflyoss/nydus/issues/1814> @BraveY
+
+## Next Meeting Schedule
+
+Date: 2026-01-27


### PR DESCRIPTION
## Description

- Include attendees, topics, actions, and issue assignments for the 2026-01-13 meeting
- Document TODO, WIP, and done issues across Dragonfly, Client, and Nydus repositories
- Schedule next meeting for 2026-01-27

## Related Issue

- https://github.com/dragonflyoss/community/issues/133
- https://github.com/dragonflyoss/community/issues/134

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
