### PR TITLE
docs(meetings): add maintainer meeting notes for 2026-02-10

### DIFF
--- a/meetings/maintainer/2026-02-10/README.md
+++ b/meetings/maintainer/2026-02-10/README.md
@@ -1,0 +1,99 @@
+# Dragonfly Community Meeting 2026-01-27
+
+## Attendees
+
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Jiale Yang](https://github.com/Yang1998-jiale) (Digital Engine)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Changfu Zhang](https://github.com/Zephyrcf) (University of Science and Technology Beijing/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Yuan Yang](https://github.com/yyzai384) (Alibaba Cloud)
+- [Baptiste Girard-Carrabin](https://github.com/Fricounet) (DataDog)
+- [Yifan Cao](https://github.com/EvanCley) (Alibaba Cloud/Dragonfly)
+
+## Topics
+
+- Unfixed issues review and assignment.
+- Update community governance document docs. @mingcheng
+- GitHub Copilot Enterprise info for CNCF maintainers @mingcheng
+- The CNCF TechDocs team is working on our documentation optimization issues. @mingcheng
+- Nomination: Baptiste Girard-Carrabin (@Fricounet) for Member @imeoer. The voting link is [here](https://github.com/dragonflyoss/community/issues/142#issuecomment-3877149308). We encourage all members to participate in the vote.
+
+## Actions
+
+- [ ] Organize topics and attendees for KubeCon 2026 EU. @mingcheng
+- [ ] Move nydus maintainers into dragonfly maintainers. @mingcheng
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+None
+
+## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+### TODO
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4604> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4600> @liyi1013
+- <https://github.com/dragonflyoss/dragonfly/issues/4590> @dask-58
+- <https://github.com/dragonflyoss/dragonfly/issues/4587> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4563> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4415> @chlins
+
+### WIP
+
+- <https://github.com/containerd/nydus-snapshotter/issues/690> @imeoer
+- <https://github.com/dragonflyoss/dragonfly/issues/4419> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4420> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4421> @chinmaychahar
+- <https://github.com/dragonflyoss/dragonfly/issues/4537> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4538> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4550> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4554> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4422> @mdxabu
+- <https://github.com/dragonflyoss/dragonfly/issues/4417> @sabarixr
+- <https://github.com/dragonflyoss/dragonfly/issues/4416> @chlins
+
+#### Dragonfly
+
+The below issues are discussed and assigned during the meeting:
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4379> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4362> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4027> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4026> @LunaWhispers
+- <https://github.com/dragonflyoss/dragonfly/issues/4025> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/3713> @baowj-678
+
+#### Dragonfly Client
+
+- <https://github.com/dragonflyoss/client/issues/1561> @pirDOL
+- <https://github.com/dragonflyoss/client/issues/1560> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1559> @CooooolFrog
+- <https://github.com/dragonflyoss/client/issues/1547> @chlins
+- <https://github.com/dragonflyoss/client/issues/1607> @chlins
+
+#### Nydus
+
+- <https://github.com/dragonflyoss/nydus/issues/1820> @bergwolf
+- <https://github.com/dragonflyoss/nydus/issues/1827> @imeoer
+- <https://github.com/dragonflyoss/nydus/issues/1826> @bergwolf
+- <https://github.com/dragonflyoss/nydus/issues/1818> @fatelei
+- <https://github.com/dragonflyoss/nydus/issues/1779> @imeoer @BraveY
+- <https://github.com/dragonflyoss/nydus/issues/1808> @BraveY
+
+### Done
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4499> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4573> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4541> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4413> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4526> @EvanCley
+- <https://github.com/dragonflyoss/client/issues/1610> @yxxhero
+- <https://github.com/dragonflyoss/client/issues/1628> @EvanCley
+
+## Next Meeting Schedule
+
+Date: 2026-03-10


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds the meeting notes for the Dragonfly Community Meeting held on 2026-01-27. 
The document records attendees, topics discussed, action items, and issue assignments across Dragonfly, Dragonfly Client, and Nydus projects.

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/community/issues/141

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
