### PR TITLE
docs(meetings): add maintainer meeting notes for 2026-03-10 (#143)

### DIFF
--- a/meetings/maintainer/2026-03-10/README.md
+++ b/meetings/maintainer/2026-03-10/README.md
@@ -1,0 +1,87 @@
+# Dragonfly Community Meeting 2026-03-10
+
+## Attendees
+
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Jiale Yang](https://github.com/Yang1998-jiale) (Digital Engine)
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Yifan Cao](https://github.com/EvanCley) (Alibaba Cloud/Dragonfly)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud/Dragonfly)
+
+## Topics
+
+- [x] Update community governance document docs. @mingcheng
+- [x] GitHub Copilot Enterprise info for CNCF maintainers @mingcheng
+- [x] Nomination: Baptiste Girard-Carrabin (@Fricounet) for Member @imeoer. The voting link is [here](https://github.com/dragonflyoss/community/issues/142#issuecomment-3877149308). We encourage all members to participate in the vote.
+
+## Actions
+
+- [ ] Organize topics and attendees for KubeCon 2026 EU. @mingcheng @gaius-qi
+- [ ] Move nydus maintainers into dragonfly maintainers. @mingcheng
+  - [PR1](https://github.com/dragonflyoss/community/pull/147)
+  - [PR2](https://github.com/dragonflyoss/nydus/pull/1888)
+- [ ] The CNCF TechDocs team is working on our documentation optimization issues. @mingcheng
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+None
+
+## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+### WIP
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4563> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4415> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4604> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4600> @liyi1013
+- <https://github.com/dragonflyoss/dragonfly/issues/4590> @dask-58
+- <https://github.com/containerd/nydus-snapshotter/issues/690> @imeoer
+- <https://github.com/dragonflyoss/dragonfly/issues/4421> @chinmaychahar
+- <https://github.com/dragonflyoss/dragonfly/issues/4550> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4422> @mdxabu
+- <https://github.com/dragonflyoss/dragonfly/issues/4417> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4416> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4379> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4362> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4027> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4026> @LunaWhispers
+- <https://github.com/dragonflyoss/dragonfly/issues/3713> @baowj-678
+- <https://github.com/dragonflyoss/dragonfly/issues/4025> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1559> @CooooolFrog
+
+### TBD
+
+- <https://github.com/dragonflyoss/nydus/issues/1827> @imeoer
+- <https://github.com/dragonflyoss/nydus/issues/1826> @bergwolf
+- <https://github.com/dragonflyoss/nydus/issues/1818> @fatelei
+- <https://github.com/dragonflyoss/nydus/issues/1779> @Zephyr
+- <https://github.com/dragonflyoss/nydus/issues/1808> @BraveY
+
+### DONE
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4587> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4419> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4420> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4537> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4538> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4554> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1561> @pirDOL
+- <https://github.com/dragonflyoss/client/issues/1560> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1547> @chlins
+- <https://github.com/dragonflyoss/client/issues/1607> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4499> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4573> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4541> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4413> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4526> @EvanCley
+- <https://github.com/dragonflyoss/client/issues/1610> @yxxhero
+- <https://github.com/dragonflyoss/client/issues/1628> @EvanCley
+- <https://github.com/dragonflyoss/nydus/issues/1820> @bergwolf
+
+## Next Meeting Schedule
+
+Date: 2026-03-24 Host by @CooooolFrog


### PR DESCRIPTION
## Description

This pull request adds the meeting notes for the Dragonfly Community Meeting held on 2026-03-10.
The document records attendees, topics discussed, action items, and issue assignments across Dragonfly, Dragonfly Client, and Nydus projects.

## Related Issue

Close https://github.com/dragonflyoss/community/issues/143