### PR TITLE
docs(meetings): add maintainer meeting notes for 2026-04-21

### DIFF
--- a/meetings/maintainer/2026-04-21/README.md
+++ b/meetings/maintainer/2026-04-21/README.md
@@ -1,0 +1,72 @@
+# Dragonfly Community Meeting 2026-04-21
+
+## Attendees
+
+- [Chenyu Zhang](https://github.com/chlins) (Ant Group/Dragonfly/Harbor)
+- [mingcheng](https://github.com/mingcheng) (The Apache Software Foundation)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Yifan Cao](https://github.com/EvanCley) (Alibaba Cloud/Dragonfly)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud/Dragonfly)
+
+## Topics
+
+None
+
+## Actions
+
+- [] review roadmap next meeting
+
+## Synchronization and discussion of community promotion activities (e.g., conference promotion, technical articles)
+
+None
+
+## Group discussion on design reviews, code reviews, issue reviews or other technical topics as needed
+
+### WIP
+
+- <https://github.com/dragonflyoss/dragonfly/issues/4415> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4604> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4590> @dask-58
+- <https://github.com/dragonflyoss/dragonfly/issues/4421> @chinmaychahar
+- <https://github.com/dragonflyoss/dragonfly/issues/4422> @mdxabu
+- <https://github.com/dragonflyoss/dragonfly/issues/4417> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4416> @chlins
+- <https://github.com/dragonflyoss/dragonfly/issues/4379> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4362> @fcgxz2003
+- <https://github.com/dragonflyoss/dragonfly/issues/4027> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4026> @LunaWhispers
+- <https://github.com/dragonflyoss/dragonfly/issues/4025> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4723> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4710> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4709> @CooooolFrog
+- <https://github.com/dragonflyoss/dragonfly/issues/4685> @mingcheng
+- <https://github.com/dragonflyoss/dragonfly/issues/4673> @CooooolFrog
+- <https://github.com/dragonflyoss/client/issues/1559> @CooooolFrog
+- <https://github.com/dragonflyoss/client/issues/1751> @mingcheng
+- <https://github.com/dragonflyoss/client/issues/1771> @EvanCley
+- <https://github.com/dragonflyoss/client/issues/1778> @YQ-Wang
+- <https://github.com/dragonflyoss/dragonfly/issues/4673> @rayne-Li
+- <https://github.com/dragonflyoss/helm-charts/issues/490> @gaius-qi
+- <https://github.com/dragonflyoss/helm-charts/issues/491> @gaius-qi
+- <https://github.com/dragonflyoss/helm-charts/issues/494> @EvanCley
+- <https://github.com/dragonflyoss/nydus/issues/1779> @Zephyr
+- <https://github.com/dragonflyoss/nydus/issues/1900> @imeoer
+- <https://github.com/dragonflyoss/nydus/issues/1924> @imeoer
+
+### TBD
+
+- <https://github.com/dragonflyoss/nydus/issues/1827> @imeoer
+
+### DONE
+
+- <https://github.com/dragonflyoss/client/issues/1719> @gaius-qi
+- <https://github.com/dragonflyoss/client/issues/1791> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/4563> @gaius-qi
+- <https://github.com/dragonflyoss/dragonfly/issues/3713> @baowj-678
+- <https://github.com/containerd/nydus-snapshotter/issues/690> @imeoer
+
+## Next Meeting Schedule
+
+Date: 2026-05-19 Host by @mingcheng


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request adds the meeting notes for the Dragonfly Community Meeting held on 2026-04-21.
The document records attendees, topics discussed, action items, and issue assignments across Dragonfly, Dragonfly Client, and Nydus projects.

## Related Issue

https://github.com/dragonflyoss/community/issues/158
