### PR TITLE
docs: add 2026-06-16 meeting notes

### DIFF
--- a/meetings/maintainer/2026-06-16/README.md
+++ b/meetings/maintainer/2026-06-16/README.md
@@ -1,0 +1,38 @@
+# Dragonfly Community Meeting 2026-06-16
+
+## Attendees
+
+- [Yifan Cao](https://github.com/EvanCley) (Alibaba Cloud/Dragonfly)
+- [mingcheng](https://github.com/mingcheng) (The ASF)
+- [Gaius](https://github.com/gaius-qi) (Ant Group/Dragonfly)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Zuliang Wang](https://github.com/CooooolFrog) (Alibaba Cloud/Dragonfly)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [Yang Yuan](https://github.com/yyzai384) (Alibaba Cloud)
+
+## Topics
+
+## Actions
+
+- [] Clean the inactive maintainer. @mingcheng
+  - NehemiahMi: <https://github.com/dragonflyoss/community/issues/171>
+  - jiangliu: <https://github.com/dragonflyoss/community/issues/172>
+  - jim3ma: <https://github.com/dragonflyoss/community/issues/173>
+- [] Add community usage rules for AI Coding. @mingcheng
+- [] Add maintainer and approver to Google Groups. @mingcheng
+- [] Using scarf to track Dragonfly community adoption. @fcgxz2003
+- [] Review the project status whether the project roadmap is on track or not. @gaius-qi
+- [] Organize the members and project associations of <https://github.com/orgs/dragonflyoss/teams>. @gaius-qi
+
+## Project Issues
+
+- Client: <https://github.com/dragonflyoss/client/issues>
+- Dragonfly: <https://github.com/dragonflyoss/dragonfly/issues>
+- Helm Charts: <https://github.com/dragonflyoss/helm-charts/issues>
+- Nydus: <https://github.com/dragonflyoss/nydus/issues>
+
+## Next Meeting
+
+- Date: 2026-06-16
+- Host: @BraveY

--- a/roles/Approvers.md
+++ b/roles/Approvers.md
@@ -6,17 +6,15 @@ This file lists the current approvers of the Dragonfly community. The list is so
 
 ## Current Approvers
 
-|                   GitHub ID                   |     Name      |            Email             |                    Company                    |
-| :-------------------------------------------: | :-----------: | :--------------------------: | :-------------------------------------------: |
-|      [imeoer](https://github.com/imeoer)      |   Song Yan    |       imeoer@gmail.com       |                   Ant Group                   |
-| [xujihui1985](https://github.com/xujihui1985) |   Jihui Xu    |    xujihui1985@gmail.com     |                   ByteDance                   |
-|   [anjia0532](https://github.com/anjia0532)   |  Anjia Zhao   |     anjia0532@gmail.com      |                   FengTeng                    |
-|  [hhhhsdxxxx](https://github.com/hhhhsdxxxx)  |   Jin Huang   |  huang_banxian@hotmail.com   |                   Ant Group                   |
-|      [BraveY](https://github.com/BraveY)      | Kaiyong Yang  | yangkaiyong.yky@antgroup.com |                   Ant Group                   |
-|  [ClementMaH](https://github.com/ClementMaH)  |  Chaozhi Ma   |       546625739@qq.com       |                    Aliyun                     |
-|    [BruceAko](https://github.com/BruceAko)    | Chongzhi Deng |     chongzhi@hust.edu.cn     | Huazhong University of Science and Technology |
-|     [Zephyr](https://github.com/Zephyrcf)     | Changfu Zhang |     zinsist777@gmail.com     | University of Science and Technology Beijing  |
-|    [EvanCley](https://github.com/EvanCley)    |   Yifan Cao   |     caoyifan1a2b@163.com     |                 Alibaba Cloud                 |
+|                   GitHub ID                   |     Name      |           Email           |                    Company                    |
+| :-------------------------------------------: | :-----------: | :-----------------------: | :-------------------------------------------: |
+| [xujihui1985](https://github.com/xujihui1985) |   Jihui Xu    |   xujihui1985@gmail.com   |                   ByteDance                   |
+|   [anjia0532](https://github.com/anjia0532)   |  Anjia Zhao   |    anjia0532@gmail.com    |                   FengTeng                    |
+|  [hhhhsdxxxx](https://github.com/hhhhsdxxxx)  |   Jin Huang   | huang_banxian@hotmail.com |                   Ant Group                   |
+|  [ClementMaH](https://github.com/ClementMaH)  |  Chaozhi Ma   |     546625739@qq.com      |                    Aliyun                     |
+|    [BruceAko](https://github.com/BruceAko)    | Chongzhi Deng |   chongzhi@hust.edu.cn    | Huazhong University of Science and Technology |
+|     [Zephyr](https://github.com/Zephyrcf)     | Changfu Zhang |   zinsist777@gmail.com    | University of Science and Technology Beijing  |
+|    [EvanCley](https://github.com/EvanCley)    |   Yifan Cao   |   caoyifan1a2b@163.com    |                 Alibaba Cloud                 |
 
 ## Emeritus Approvers
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates meeting documentation and corrects the formatting in the approvers list. The key changes are the addition of a new meeting notes file for the upcoming maintainer meeting and a fix to the table formatting in the approvers list.

Meeting documentation:

* Added a new meeting notes file `meetings/maintainer/2026-06-16/README.md` for the Dragonfly Community Meeting scheduled for June 16, 2026, including attendees, topics, action items, project issues, and next meeting details.

Approvers list formatting:

* Fixed the table formatting in `roles/Approvers.md` by correcting the column alignment and removing a duplicate entry for `BraveY`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
