### PR TITLE
docs(roles): Remove duplicate emeritus maintainer entries 🧹

### DIFF
--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -46,10 +46,6 @@ Below is the list of emeritus (retired) maintainers. Thank them for their contri
 |         [liubin](https://github.com/liubin)         |     Bin Liu     |    lb203159@antgroup.com     |   Ant Group   |
 |     [changweige](https://github.com/changweige)     |   Changwei Ge   |      gechangwei@live.cn      |   ByteDance   |
 |      [hsiangkao](https://github.com/hsiangkao)      |    Xiang Gao    | hsiangkao@linux.alibaba.com  | Alibaba Group |
-|    [liubogithub](https://github.com/liubogithub)    |     Bo Liu      |     liub.liubo@gmail.com     | Alibaba Group |
-|     [changweige](https://github.com/changweige)     |   Changwei Ge   |      gechangwei@live.cn      |   ByteDance   |
-|      [hsiangkao](https://github.com/hsiangkao)      |    Xiang Gao    | hsiangkao@linux.alibaba.com  | Alibaba Group |
-|         [liubin](https://github.com/liubin)         |     Bin Liu     |    lb203159@antgroup.com     |   Ant Group   |
 |       [jiangliu](https://github.com/jiangliu)       |    Jiang Liu    |   gerry@linux.alibaba.com    | Alibaba Group |
 |         [jim3ma](https://github.com/jim3ma)         |     Jim Ma      |     majinjing3@gmail.com     |   Ant Group   |
 |     [NehemiahMi](https://github.com/NehemiahMi)     |  PengCheng Liu  |  josephcharity@hotmail.com   |   Ant Group   |


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- remove duplicate retired maintainer rows from the emeritus table


<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
