### PR TITLE
docs: add AI usage policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,11 @@ go mod tidy
 
 You'll need to commit the changes to `go.mod` and `go.sum` before submitting your pull request.
 
+## AI Usage Policy
+
+This project does not accept fully AI-generated contributions. AI tools may be used assistively only.
+You must understand, verify, and take full responsibility for every change you submit.
+
 ## Getting Involved
 
 There are many ways to get involved and help the Dragonfly community. Whether you're a developer, a user, or just an enthusiast, we'd love to have you!


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adds AI Usage Policy section to CONTRIBUTING.md
- Prohibits fully AI-generated contributions
- Requires contributors to understand, verify, and own every change they submit
- AI tools are permitted only in an assistive capacity
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
