### PR TITLE
add Zephyrcf to maintainers and update 07-14 meeting notes

### DIFF
--- a/meetings/maintainer/2026-07-14/README.md
+++ b/meetings/maintainer/2026-07-14/README.md
@@ -1,0 +1,34 @@
+# Dragonfly Community Meeting 2026-07-14
+
+## Attendees
+
+- [Yifan Cao](https://github.com/EvanCley) (Alibaba Cloud/Dragonfly)
+- [mingcheng](https://github.com/mingcheng) (The ASF)
+- [Kaiyong Yang](https://github.com/BraveY) (Ant Group/Nydus)
+- [Zhou Xu](https://github.com/fcgxz2003) (Dalian University of Technology/Dragonfly)
+- [Song Yan](https://github.com/imeoer) (Ant Group/Nydus)
+- [yxxhero](https://github.com/yxxhero)
+- [Changfu Zhang](https://github.com/Zephyrcf) (University of Science and Technology Beijing/Nydus)
+
+## Topics
+
+## Done
+
+- [x] Nydus v3 Evolution Roadmap and Features.
+
+## Actions
+
+- [ ] Pre-nominate @Zephyrcf as a maintainer for the nydus project. @imeoer
+- [ ] Check why @Fricounet lost maintainer privileges and restore them. @mingcheng
+
+## Project Issues
+
+- Client: <https://github.com/dragonflyoss/client/issues>
+- Dragonfly: <https://github.com/dragonflyoss/dragonfly/issues>
+- Helm Charts: <https://github.com/dragonflyoss/helm-charts/issues>
+- Nydus: <https://github.com/dragonflyoss/nydus/issues>
+
+## Next Meeting
+
+- Date: 2026-07-28
+- Host: @fcgxz2003

--- a/roles/Maintainers.md
+++ b/roles/Maintainers.md
@@ -7,6 +7,7 @@ This document lists the current maintainers of the Dragonfly community. The list
 |                    GitHub ID                    |           Name           |                 Email                 |             Company             |
 | :---------------------------------------------: | :----------------------: | :-----------------------------------: | :-----------------------------: |
 |    [Fricounet](https://github.com/Fricounet)    | Baptiste Girard-Carrabin | baptiste.girardcarrabin@datadoghq.com |             DataDog             |
+|  [Zephyrcf](https://github.com/Zephyrcf)  |       Changfu Zhang       |          zinsist777@gmail.com          |          University of Science and Technology Beijing          |
 |       [chlins](https://github.com/chlins)       |       Chlins Zhang       |        chlins.zhang@gmail.com         |            Broadcom             |
 |    [mingcheng](https://github.com/mingcheng)    |        Fengjun Lv        |         mingcheng@apache.org          |        Apache Foundation        |
 |     [gaius-qi](https://github.com/gaius-qi)     |         Gaius Qi         |          gaius.qi@gmail.com           |            ByteDance            |


### PR DESCRIPTION
- Add @Zephyrcf to maintainer list via https://github.com/dragonflyoss/community/issues/186.
- Close https://github.com/dragonflyoss/community/issues/182 and https://github.com/dragonflyoss/community/issues/186